### PR TITLE
Additional TCK cleanup/updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,47 @@
         </license>
     </licenses>
 
+    <organization>
+        <name>Eclipse Foundation</name>
+        <url>http://www.eclipse.org/</url>
+    </organization>
+
+    <issueManagement>
+        <system>GitHub</system>
+        <url>https://github.com/eclipse/microprofile-jwt-auth/issues</url>
+    </issueManagement>
+
+    <developers>
+        <developer>
+            <name>Scott M Stark</name>
+            <url>https://github.com/starksm64</url>
+            <organization>Red Hat</organization>
+            <organizationUrl>https://www.jboss.org</organizationUrl>
+        </developer>
+    </developers>
+
+    <scm>
+        <connection>scm:git:https://github.com/eclipse/microprofile-jwt-auth.git</connection>
+        <developerConnection>scm:git:https://github.com/eclipse/microprofile-jwt-auth.git</developerConnection>
+        <url>https://github.com/eclipse/microprofile-jwt-auth</url>
+        <tag>HEAD</tag>
+    </scm>
+
+    <distributionManagement>
+        <repository>
+            <id>repo.eclipse.org</id>
+            <name>Eclipse MicroProfile Repository - Releases</name>
+            <url>https://repo.eclipse.org/content/repositories/microprofile-releases/</url>
+        </repository>
+        <snapshotRepository>
+            <id>repo.eclipse.org</id>
+            <name>Eclipse MicroProfile Repository - Snapshots</name>
+            <url>https://repo.eclipse.org/content/repositories/microprofile-snapshots/</url>
+
+            <uniqueVersion>true</uniqueVersion>  <!-- for keeping multipe snapshot versions - maybe for staging a final version besides nightly versions -->
+
+        </snapshotRepository>
+    </distributionManagement>
 
     <modules>
         <module>api</module>

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -122,29 +122,33 @@
 
     <profiles>
         <profile>
-            <!-- The weld-se profile is a base profile used to test the basics of a JWTPrincipal implementation
+            <!-- The tokens profile is a base profile used to test the basics of a JWTPrincipal implementation
+            using an implementation provided org.eclipse.microprofile.jwt.tck.util.ITokenParser via a service provider
+            using the ServiceLoader pattern.
             -->
-            <id>weld-se</id>
+            <id>tokens-se</id>
             <properties>
-                <tck.includes>org.eclipse.microprofile.jwt.tck.format.TokenParsingTest</tck.includes>
+                <tck.includes>org.eclipse.microprofile.jwt.tck.parsing.TokenValidationTest</tck.includes>
             </properties>
 
             <dependencies>
                 <dependency>
-                    <groupId>org.jboss.weld.se</groupId>
-                    <artifactId>weld-se-core</artifactId>
-                    <version>2.4.3.Final</version>
-                </dependency>
-                <dependency>
-                    <groupId>org.jboss.arquillian.container</groupId>
-                    <artifactId>arquillian-weld-se-embedded-1.1</artifactId>
-                    <version>1.0.0.Final</version>
+                    <!--
+                    These need to be specified as system properties on mvn command line:
+                    mvn -Pcontainer -Dtck.container.groupId=org.wildfly.swarm -Dtck.container.artifactId=jwt-auth-tck \
+                    -Dtck.container.version=1.0-SNAPSHOT test
+                    -->
+                    <groupId>${tck.container.groupId}</groupId>
+                    <artifactId>${tck.container.artifactId}</artifactId>
+                    <version>${tck.container.version}</version>
+                    <scope>test</scope>
                 </dependency>
             </dependencies>
         </profile>
         <profile>
             <id>container</id>
             <properties>
+                <!-- Include all tests under the org.eclipse.microprofile.jwt.tck.container package -->
                 <tck.includes>**/container/**/*Test.java</tck.includes>
             </properties>
             <dependencies>

--- a/tck/running_the_tck.asciidoc
+++ b/tck/running_the_tck.asciidoc
@@ -153,8 +153,48 @@ The
 
 == Running Your Implementation With the TCK
 Once you have built and installed your TCK harness artifact, you can run the
-TCK tests against it by using the container profile via the following command
+TCK tests against it by using either the tokens-se or container profiles.
+
+=== tokens-se Profile
+The tokens-se profile is a basic unit test for validation of your JWTPrincipal implementation. This does not require
+any special test container runner. This test does require that your TCK harness artifact provide an implementation of
+the `org.eclipse.microprofile.jwt.tck.util.ITokenParser` interface using a service provider via the
+`java.util.ServiceLoader` pattern, that is, there should be a META-INF/services/org.eclipse.microprofile.jwt.tck.util.ITokenParser
+file in your TCK harness artifact that points to your ITokenParser implementation.
+
+To run the unit tests associated with the tokens-se profile, run the following command
 from within the microprofile-jwt-auth/tck directory:
+
+`mvn -Ptokens-se -Dtck.container.groupId={MY_GROUP} -Dtck.container.artifactId={MY_ARTIFACT} -Dtck.container.version={MY_VERSION} test`
+
+where you would replace the `{MY_GROUP}`, `{MY_ARTIFACT}` and `{MY_VERSION}` with
+the `<groupId>...<groupId>`, `<artifactId>...</artifactId>`, and `<version>...</version>`
+respectively from your TCK harness artifact.
+
+A concrete example is for running with the TCK harness artifiact from the
+https://github.com/MicroProfileJWT/wfswarm-jwt-auth-tck project is:
+
+`mvn -Ptokens-se -Dtck.container.groupId=org.wildfly.swarm -Dtck.container.artifactId=jwt-auth-tck -Dtck.container.version=1.0-SNAPSHOT test`
+
+=== container Profile
+The container profile is a test of JAX-RS client tests that validate a JAX-RS endpoint bundled in a WebArchive deployment
+via your implementation. These tests require Arquillian container runtime integration to properly deploy and start
+your container. You typically provide this via a dependency on an arquillian container artificat, for example,
+Tomcat based containers might include a dependency like:
+
+```
+<dependency>
+  <groupId>org.jboss.arquillian.container</groupId>
+  <artifactId>arquillian-tomcat-embedded-7</artifactId>
+  <version>1.0.0</version>
+  <scope>test</scope>
+</dependency>
+```
+
+This test of tests also require the  `org.jboss.arquillian.core.spi.LoadableExtension` and `org.jboss.arquillian.container.test.spi.client.deployment.ApplicationArchiveProcessor`
+implementations as discussed above.
+
+To run this set of tests, issue the following command from within the microprofile-jwt-auth/tck directory:
 
 `mvn -Pcontainer -Dtck.container.groupId={MY_GROUP} -Dtck.container.artifactId={MY_ARTIFACT} -Dtck.container.version={MY_VERSION} test`
 

--- a/tck/src/test/java/org/eclipse/microprofile/jwt/tck/parsing/TokenValidationTest.java
+++ b/tck/src/test/java/org/eclipse/microprofile/jwt/tck/parsing/TokenValidationTest.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright (c) 2016-2017 Contributors to the Eclipse Foundation
+ *
+ *  See the NOTICE file(s) distributed with this work for additional
+ *  information regarding copyright ownership.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  You may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.eclipse.microprofile.jwt.tck.parsing;
+
+import org.eclipse.microprofile.jwt.JWTPrincipal;
+import org.eclipse.microprofile.jwt.tck.util.ITokenParser;
+import org.eclipse.microprofile.jwt.tck.util.TokenUtils;
+import org.jboss.arquillian.junit.Arquillian;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.security.PublicKey;
+import java.util.HashSet;
+import java.util.ServiceLoader;
+import java.util.Set;
+
+/**
+ * Basic token parsing and validation tests for JWTPrincipal implementations
+ */
+@RunWith(Arquillian.class)
+public class TokenValidationTest {
+    private static final String TEST_ISSUER = "https://server.example.com";
+    /** */
+    private static ITokenParser tokenParser;
+    /** */
+    private static PublicKey publicKey;
+
+    @BeforeClass
+    public static void initClass() throws Exception {
+        publicKey = TokenUtils.readPublicKey("/publicKey.pem");
+        if(publicKey == null) {
+            throw new IllegalStateException("Failed to load /publicKey.pem resource");
+        }
+
+        // Load a
+        ServiceLoader<ITokenParser> serviceLoader = ServiceLoader.load(ITokenParser.class);
+        if(serviceLoader.iterator().hasNext() == false) {
+            throw new IllegalStateException(String.format("An %s service provider is required", ITokenParser.class.getName()));
+        }
+        tokenParser = serviceLoader.iterator().next();
+        if(tokenParser == null) {
+            throw new IllegalStateException(String.format("Service provider for %s  produced a null parser", ITokenParser.class.getName()));
+        }
+    }
+
+    /**
+     * Create a JWT token representation of the testRIJWTCallerPrincipal.json test resource and then parse it into a
+     * JWTPrincipal to validate the container's implementation.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testRIJWTCallerPrincipal() throws Exception {
+        long nowInSeconds = System.currentTimeMillis() / 1000;
+        String jwt = TokenUtils.generateTokenString("/testRIJWTCallerPrincipal.json");
+        System.out.printf("jwt: %s\n", jwt);
+        JWTPrincipal jwtPrincipal = tokenParser.parse(jwt, TEST_ISSUER, publicKey);
+        System.out.printf("Parsed caller principal: %s\n", jwtPrincipal);
+
+        // Validate the required claims
+        Assert.assertEquals("bearer_token", jwt, jwtPrincipal.getRawToken());
+        Assert.assertEquals("iss", "https://server.example.com", jwtPrincipal.getIssuer());
+        Assert.assertEquals("sub", "24400320", jwtPrincipal.getSubject());
+        Assert.assertEquals("aud", "s6BhdRkqt3", jwtPrincipal.getAudience().toArray()[0]);
+        Assert.assertEquals("name", "jdoe@example.com", jwtPrincipal.getName());
+        Assert.assertEquals("jti", "a-123", jwtPrincipal.getTokenID());
+        Assert.assertTrue("exp is > nowInSeconds", jwtPrincipal.getExpirationTime() > nowInSeconds);
+        Assert.assertTrue("iat is >= nowInSeconds", jwtPrincipal.getIssuedAtTime() >= nowInSeconds);
+
+        // Validate the groups
+        Set<String> groups = jwtPrincipal.getGroups();
+        String[] expectedGroupNames = {"group1", "group2", "role-in-realm", "user", "manager"};
+        HashSet<String> missingGroups = new HashSet<>();
+        for (String group : expectedGroupNames) {
+            if(!groups.contains(group)) {
+                missingGroups.add(group);
+            }
+        }
+        if(missingGroups.size() > 0) {
+            Assert.fail("There are missing groups: "+missingGroups);
+        }
+
+        // Validate other claims
+        Object authTime = jwtPrincipal.getClaim("auth_time");
+        Assert.assertTrue("auth_time is a Number", authTime instanceof Number);
+        Assert.assertTrue("auth_time as int is >= nowInSeconds", nowInSeconds <= ((Number)authTime).intValue());
+
+        String preferredName = (String) jwtPrincipal.getClaim("preferred_username");
+        Assert.assertEquals("preferred_username is jdoe", "jdoe", preferredName);
+    }
+
+    /**
+     * Validate that the updates jwt-content1.json verifies against current time
+     * @throws Exception - thrown are parse failure
+     * @see TokenUtils#generateTokenString(String)
+     */
+    @Test
+    @Ignore("Internal test to validate the behavior of TokenUtils.generateTokenString")
+    public void testUtilsToken() throws Exception {
+        String jwt = TokenUtils.generateTokenString("/jwt-content1.json");
+        JWTPrincipal callerPrincipal = tokenParser.parse(jwt, TEST_ISSUER, publicKey);
+        System.out.println(callerPrincipal);
+        long nowSec = System.currentTimeMillis() / 1000;
+        long iss = callerPrincipal.getIssuedAtTime();
+        Assert.assertTrue(String.format("now(%d) < 1s from iss(%d)", nowSec, iss), (nowSec - iss) < 1);
+        long exp = callerPrincipal.getExpirationTime();
+        Assert.assertTrue(String.format("now(%d) > 299s from exp(%d)", nowSec, exp), (exp - nowSec) > 299);
+    }
+
+    /**
+     * Validate that a token that is past is exp claim should fail the parse verification
+     * @throws Exception - expect a Exception
+     */
+    @Test()
+    public void testExpiredValidation() throws Exception {
+        HashSet<TokenUtils.InvalidFields> invalidFields = new HashSet<>();
+        invalidFields.add(TokenUtils.InvalidFields.EXP);
+        String jwt = TokenUtils.generateTokenString("/jwt-content1.json", invalidFields);
+        try {
+            JWTPrincipal callerPrincipal = tokenParser.parse(jwt, TEST_ISSUER, publicKey);
+            Assert.fail("Was able to parse the token: " + callerPrincipal);
+        }
+        catch (Exception e) {
+            Throwable cause = e.getCause();
+            System.out.printf("Failed as expected with cause: %s\n", cause.getMessage());
+        }
+    }
+
+    /**
+     * Validate that if an issuer other than {@link #TEST_ISSUER} is used on the token, the token fails to validate
+     * @throws Exception thrown on unexpected error
+     */
+    @Test
+    public void testBadIssuer() throws Exception {
+        // Indicate that TokenUtils should overwrite the issuer with "INVALID_ISSUER"
+        HashSet<TokenUtils.InvalidFields> invalidFields = new HashSet<>();
+        invalidFields.add(TokenUtils.InvalidFields.ISSUER);
+        String jwt = TokenUtils.generateTokenString("/jwt-content1.json", invalidFields);
+        PublicKey publicKey = TokenUtils.readPublicKey("/publicKey.pem");
+        try {
+            JWTPrincipal callerPrincipal = tokenParser.parse(jwt, TEST_ISSUER, publicKey);
+            Assert.fail("Was able to parse the token: " + callerPrincipal);
+        }
+        catch (Exception e) {
+            Throwable cause = e.getCause();
+            System.out.printf("Failed as expected with cause: %s\n", cause.getMessage());
+        }
+    }
+
+    @Test
+    public void testBadSigner() throws Exception {
+        HashSet<TokenUtils.InvalidFields> invalidFields = new HashSet<>();
+        invalidFields.add(TokenUtils.InvalidFields.SIGNER);
+        String jwt = TokenUtils.generateTokenString("/jwt-content1.json", invalidFields);
+        try {
+            JWTPrincipal callerPrincipal = tokenParser.parse(jwt, TEST_ISSUER, publicKey);
+            Assert.fail("Was able to parse the token: " + callerPrincipal);
+        }
+        catch (Exception e) {
+            Throwable cause = e.getCause();
+            System.out.printf("Failed as expected with cause: %s\n", cause.getMessage());
+        }
+    }
+
+}

--- a/tck/src/test/resources/jwt-content1.json
+++ b/tck/src/test/resources/jwt-content1.json
@@ -1,0 +1,32 @@
+{
+    "iss": "https://server.example.com",
+    "jti": "a-123",
+    "sub": "24400320",
+    "upn": "jdoe@example.com",
+    "preferred_username": "jdoe",
+    "aud": "s6BhdRkqt3",
+    "exp": 1311281970,
+    "iat": 1311280970,
+    "auth_time": 1311280969,
+    "groups": ["role-in-realm", "user", "manager", "group1", "group2"],
+    "resource_access": {
+        "my-service": {
+            "groups": [
+                "group1",
+                "group2",
+                "role-in-my-service"
+            ],
+        },
+        "service-B": {
+            "groups": [
+                "role-in-B"
+            ]
+        },
+        "service-C": {
+            "groups": [
+                "groupC",
+                "web-tier"
+            ]
+        }
+    }
+}

--- a/tck/src/test/resources/testRIJWTCallerPrincipal.json
+++ b/tck/src/test/resources/testRIJWTCallerPrincipal.json
@@ -8,32 +8,25 @@
   "exp": 1311281970,
   "iat": 1311280970,
   "auth_time": 1311280969,
-  "roles": [
-    "role-in-realm",
-    "user",
-    "manager"
-  ],
-  "groups": ["group1", "group2"],
+  "groups": ["group1", "group2", "role-in-realm", "user", "manager"],
   "resource_access": {
-    "my-service": {
-      "groups": [
-        "group1",
-        "group2"
-      ],
-      "roles": [
-        "role-in-my-service"
-      ]
-    },
-    "service-B": {
-      "roles": [
-        "role-in-B"
-      ]
-    },
-    "service-C": {
-      "groups": [
-        "groupC",
-        "web-tier"
-      ]
-    }
+      "my-service": {
+          "groups": [
+              "group1",
+              "group2",
+              "role-in-my-service"
+          ],
+          "service-B": {
+              "groups": [
+                  "role-in-B"
+              ]
+          },
+          "service-C": {
+              "groups": [
+                  "groupC",
+                  "web-tier"
+              ]
+          }
+      }
   }
 }


### PR DESCRIPTION
- Begin adding release information to root pom
- Add the basic JWTPrincipal token parsing test and rename weld-se to tokens-se as CDI is not used. This drops weld-se dependency.
- Update the TCK run instructions to discuss both profiles

Signed-off-by: Scott M Stark <starksm64@gmail.com>