### PR TITLE
TCK and documentation updates

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/jwt/Claim.java
+++ b/api/src/main/java/org/eclipse/microprofile/jwt/Claim.java
@@ -26,7 +26,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Annotation used to signify and injection point for a {@link ClaimValue} from
+ * Annotation used to signify an injection point for a {@link ClaimValue} from
  * a {@link JsonWebToken}
  */
 @Qualifier

--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
         <dependencies>
             <dependency>
                 <groupId>javax</groupId>
-                <artifactId>javaee-web-api</artifactId>
+                <artifactId>javaee-api</artifactId>
                 <type>pom</type>
                 <version>7.0</version>
                 <scope>import</scope>
@@ -122,6 +122,13 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
                     <version>3.0.2</version>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>test-jar</goal>
+                            </goals>
+                        </execution>
+                    </executions>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/spec/src/main/asciidoc/interoperability.asciidoc
+++ b/spec/src/main/asciidoc/interoperability.asciidoc
@@ -17,25 +17,25 @@
 
 ## Recommendations for Interoperability
 
-The decision about using MicroProfile JWT(MP-JWT) as a token format depends on the agreement between both identity
+The maximum utility of the MicroProfile JWT(MP-JWT) as a token format depends on the agreement between both identity
 providers and service providers. This means identity providers - responsible for issuing tokens - should be able to
-issue tokens using the JWT format in a way that service providers can understand in order to introspect the token and
+issue tokens using the MP-JWT format in a way that service providers can understand in order to introspect the token and
 gather information about a subject. To that end, the requirements for the MicroProfile JWT are:
 
-1. An authentication token.
-2. An authorization token that contains Java EE application level roles indirectly granted via groups.
+1. Be usable as an authentication token.
+2. Be usable as an authorization token that contains Java EE application level roles indirectly granted via a groups claim.
 3. Can be mapped to IdentityStore in JSR375.
 4. Can support additional standard claims described in https://www.iana.org/assignments/jwt/jwt.xhtml as
 well as non-standard claims.
 
 To meet those requirements, we introduce 2 new claims to the MP-JWT:
 
-* "upn": A human readable claim that uniquely identifies the subject or user principal of token, across
+* "upn": A human readable claim that uniquely identifies the subject or user principal of the token, across
 the MicroProfile services the token will be accessed with.
-* "groups": The token subject's group membership that will be mapped to Java EE application
-level roles.
+* "groups": The token subject's group memberships that will be mapped to Java EE style application
+level roles in the MicroProfile service container.
 
-### Required Claims
+### Minimum MMP-JWT Required Claims
 The required minimum set of MP-JWT claims is then:
 
 typ:: This JOSE header parameter identifies the token as an RFC7519 and must be "JWT" https://tools.ietf.org/html/rfc7519#section-5.1[RFC7519, Section 5.1]
@@ -373,7 +373,7 @@ integration is with the JAX-RS container, and injection of the MP-JWT types.
 
 #### Injection of `JsonWebToken`
 An MP-JWT implementation must support the injection of the currently authenticated
-caller as a JsonWebToken with @RequestScoped:
+caller as a JsonWebToken with @RequestScoped scope:
 
 ```java
 @Path("/endp")
@@ -388,12 +388,65 @@ public class RolesEndpoint {
 #### Injection of `ClaimValue`
 
 This specification requires support for injection of claims from the current
-`JsonWebToken` using the `org.eclipse.microprofile.jwt.@Claim` qualifier and
-`org.eclipse.microprofile.jwt.ClaimValue` interface with with @RequestScoped scoping.
-The following example code fragment illustrates various examples of injecting
-different types of claims using a range of generic forms of the `ClaimValue`:
+`JsonWebToken` using the `org.eclipse.microprofile.jwt.Claim` qualifier:
 
-```java
+[source,java]
+----
+/**
+ * Annotation used to signify an injection point for a {@link ClaimValue} from
+ * a {@link JsonWebToken}
+ */
+@Qualifier
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER})
+public @interface Claim {
+    /**
+     * The value specifies the id name the claim to inject
+     * @return the claim name
+     * @see JsonWebToken#getClaim(String)
+     */
+    String value() default "";
+
+    /**
+     * An alternate way of specifying a claim name using the {@linkplain Claims}
+     * enum
+     * @return the claim enum
+     */
+    Claims standard() default Claims.UNKNOWN;
+
+}
+----
+
+and `org.eclipse.microprofile.jwt.ClaimValue` interface:
+[source,java]
+----
+/**
+ * A representation of a claim in a {@link JsonWebToken}
+ * @param <T> the expected type of the claim
+ */
+public interface ClaimValue<T> extends Principal {
+
+    /**
+     * Access the name of the claim.
+     * @return The name of the claim as seen in the JsonWebToken content
+     */
+    @Override
+    public String getName();
+
+    /**
+     * Access the value of the claim.
+     * @return the value of the claim.
+     */
+    public T getValue();
+}
+----
+
+with @RequestScoped scoping. The following example code fragment illustrates various
+examples of injecting different types of claims using a range of generic forms of
+the `ClaimValue`:
+
+[source,java]
+----
 import org.eclipse.microprofile.jwt.Claim;
 import org.eclipse.microprofile.jwt.ClaimValue;
 import org.eclipse.microprofile.jwt.Claims;
@@ -403,7 +456,7 @@ import org.eclipse.microprofile.jwt.Claims;
 public class RolesEndpoint {
 ...
 
-    @Inject
+    @Inject // <1>
     @Claim(standard = Claims.raw_token)
     private ClaimValue<String> rawToken;
     @Inject
@@ -412,20 +465,20 @@ public class RolesEndpoint {
     @Inject
     @Claim(standard = Claims.jti)
     private ClaimValue<String> jti;
-    @Inject
+    @Inject // <2>
     @Claim("jti")
     private ClaimValue<Optional<String>> optJTI;
     @Inject
     @Claim("jti")
     private ClaimValue objJTI;
-    @Inject
+    @Inject // <3>
     @Claim("aud")
     private ClaimValue<Set<String>> aud;
     @Inject
     @Claim("groups")
     private ClaimValue<Set<String>> groups;
-    @Inject
-    @Claim("iat")
+    @Inject // <4>
+    @Claim(standard=Claims.iat)
     private ClaimValue<Long> issuedAt;
     @Inject
     @Claim("iat")
@@ -436,22 +489,57 @@ public class RolesEndpoint {
     @Inject
     @Claim("auth_time")
     private ClaimValue<Optional<Long>> authTime;
-    @Inject
+    @Inject // <5>
     @Claim("custom-missing")
     private ClaimValue<Optional<Long>> custom;
-```
+----
+<1> Injection of the raw MP-JWT token string.
+<2> Injection of the jti token id as an `Optional<String>` wapper.
+<3> Injection of the aud audience claim as a Set<String>. This is the required
+type as seen by looking at the Claims.aud enum value's Java type member.
+<4> Injection of the issued at time claim using an @Claim that references the
+claim name using the Claims.iat enum value.
+<5> Injection of a custom claim that does exist will result in an Optional<Long>
+value for which isPresent() will return false.
 
 The example shows that one may specify the name of the claim using with a
-string or a Claims enum value. The string form would allow for specifying non-standard
-claims while the Claims enum approach guards against typos and misspellings.
+string or a `Claims` enum value. The string form would allow for specifying non-standard
+claims while the `Claims` enum approach guards against typos and mis-spellings.
 
 The `@RequestScoped` requirement does introduce some additional complexity for
 a CDI extension as a producer method cannot have the
 `javax.enterprise.inject.spi.InjectionPoint` provided as a parameter to allow
 for distinguishing type. This requires that the CDI extension collect the `ClaimValue`
-injection sites by @Claim value and `ClaimValue` type. An example of one way
+injection sites by `@Claim` value and `ClaimValue` type. An example of one way
 to accomplish this via dynamic producer methods is shown in this prototype
 extension: https://github.com/MicroProfileJWT/microprofile-jwt-auth-wfswarm/blob/master/src/main/java/org/eclipse/microprofile/jwt/wfswarm/cdi/MPJWTExtension.java[MPJWTExtension].
+
+#### Injection of Claim Values using `javax.inject.Provider<?>`
+An MP-JWT implementation is required to support injection of the currently
+authenticated `JsonWebToken` claim values using the `javax.inject.Provider<?>`
+wrapper as the injection site type as shown in this code fragment:
+
+[source,java]
+----
+@Path("/endp")
+@ApplicationScoped
+public class RolesEndpoint {
+...
+
+    @Inject
+    @Claim(standard = Claims.jti)
+    private Provider<String> providerJTI;
+    @Inject
+    @Claim(standard = Claims.iat)
+    private Provider<Long> providerIAT;
+    @Inject
+    @Claim("groups")
+    private Provider<Set<String>> providerGroups;
+----
+
+### JAX-RS Container API Integration
+The behavior of the following JAX-RS security related methods is required for
+MP-JWT implementations.
 
 #### `javax.ws.rs.core.SecurityContext.getUserPrincipal()`
 The `java.security.Principal` returned from these methods MUST be an instance of `org.eclipse.microprofile.jwt.JsonWebToken`.

--- a/spec/src/main/asciidoc/microprofile-jwt-auth-spec.asciidoc
+++ b/spec/src/main/asciidoc/microprofile-jwt-auth-spec.asciidoc
@@ -18,8 +18,8 @@
 = Interoperable JWT RBAC for Microprofile
 :author: Scott Stark; Pedro Igor Silva
 :email: sstark@redhat.com
-:revnumber: 0.2 Draft
-:revdate: 2017-07-27
+:revnumber: 1.0 Draft
+:revdate: 2017-08-23
 :revremark: Proposal
 :version-label!:
 :sectanchors:

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -30,10 +30,12 @@
 
     <properties>
         <version.shrinkwrap.resolvers>2.2.6</version.shrinkwrap.resolvers>
+        <version.testng>6.10</version.testng>
         <checkstyle.methodNameFormat>^_?[a-z][a-zA-Z0-9_]*$</checkstyle.methodNameFormat>
         <!-- TCK properties that must be overriden in the vendor profile -->
         <tck.ITokenParserArtifact>INVALID</tck.ITokenParserArtifact>
         <tck.includes>INVALID</tck.includes>
+        <tck.testSuite>tck-null-suite.xml</tck.testSuite>
     </properties>
 
     <dependencies>
@@ -67,6 +69,19 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>javax.security.jacc</groupId>
+            <artifactId>javax.security.jacc-api</artifactId>
+            <version>1.5</version>
+            <scope>provided</scope>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>javax.ejb</groupId>
+            <artifactId>ejb-api</artifactId>
+            <version>3.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>com.nimbusds</groupId>
             <artifactId>nimbus-jose-jwt</artifactId>
             <version>4.23</version>
@@ -77,10 +92,9 @@
         </dependency>
 
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.12</version>
-            <scope>test</scope>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <version>${version.testng}</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.arquillian.container</groupId>
@@ -91,15 +105,13 @@
             <artifactId>arquillian-container-test-spi</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss.arquillian.junit</groupId>
-            <artifactId>arquillian-junit-container</artifactId>
-            <scope>test</scope>
+            <groupId>org.jboss.arquillian.testng</groupId>
+            <artifactId>arquillian-testng-container</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss.shrinkwrap.resolver</groupId>
             <artifactId>shrinkwrap-resolver-depchain</artifactId>
             <version>${version.shrinkwrap.resolvers}</version>
-            <scope>test</scope>
             <type>pom</type>
         </dependency>
     </dependencies>
@@ -112,15 +124,17 @@
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>2.20</version>
                     <configuration>
-                        <includes>
-                            <include>${tck.includes}</include>
-                        </includes>
-                        <forkCount>1</forkCount>
+                        <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                        <suiteXmlFiles>
+                            <suiteXmlFile>${tck.testSuite}</suiteXmlFile>
+                        </suiteXmlFiles>
+                        <environmentVariables>
+                        </environmentVariables>
                         <systemPropertyVariables>
-                            <tck.ITokenParserArtifact>${tck.ITokenParserArtifact}</tck.ITokenParserArtifact>
-                            <buildDirectory>${project.build.directory}</buildDirectory>
                         </systemPropertyVariables>
-
+                        <forkCount>1</forkCount>
+                        <reuseForks>true</reuseForks>
+                        <trimStackTrace>false</trimStackTrace>
                     </configuration>
                 </plugin>
             </plugins>
@@ -155,8 +169,26 @@
         <profile>
             <id>container</id>
             <properties>
-                <!-- Include all tests under the org.eclipse.microprofile.jwt.tck.container package -->
-                <tck.includes>**/container/**/*Test.java</tck.includes>
+                <tck.testSuite>tck-base-suite.xml</tck.testSuite>
+            </properties>
+            <dependencies>
+                <dependency>
+                    <!--
+                    These need to be specified as system properties on mvn command line:
+                    mvn -Pcontainer -Dtck.container.groupId=org.wildfly.swarm -Dtck.container.artifactId=jwt-auth-tck \
+                    -Dtck.container.version=1.0-SNAPSHOT test
+                    -->
+                    <groupId>${tck.container.groupId}</groupId>
+                    <artifactId>${tck.container.artifactId}</artifactId>
+                    <version>${tck.container.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>container-full</id>
+            <properties>
+                <tck.testSuite>tck-full-suite.xml</tck.testSuite>
             </properties>
             <dependencies>
                 <dependency>

--- a/tck/running_the_tck.asciidoc
+++ b/tck/running_the_tck.asciidoc
@@ -25,7 +25,7 @@ to augment the base `org.jboss.shrinkwrap.api.spec.WebArchive` with the
 implementation specific artifacts, descriptors, libraries, etc. needed for
 the implementation to properly deploy the test web archive.
 
-There are base implementations of the LoadableExtension and ApplicationArchiveProcessor
+There are base implementations of the `LoadableExtension` and `ApplicationArchiveProcessor`
 that can be used for strait-forward augmentation scenarios, but you can always
 provide your own implementations. An example of the former is:
 https://github.com/MicroProfileJWT/wfswarm-jwt-auth-tck-viabase
@@ -35,14 +35,15 @@ https://github.com/MicroProfileJWT/wfswarm-jwt-auth-tck
 
 == Creating Your Implementation TCK Harness Artifact
 As described, you need to create an artifact that bundles a LoadableExtension
-as Java ServiceProvider that installs an ApplicationArchiveProcessor that
+using a Java ServiceProvider that installs an ApplicationArchiveProcessor that
 augments the base TCK test web application archive with the implementation specific
 configuration and dependencies needed to successfully deploy and test the web
 application with MP-JWT authentication enabled.
 
-The
+An example skeleton pom.xml is shown here:
 
-```maven
+[source,maven]
+----
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
     Licensed under the Apache License, Version 2.0 (the
@@ -86,13 +87,13 @@ The
     </dependencyManagement>
 
     <dependencies>
-        <!-- This is the MP-JWT TCK base extension and utility classes -->
+        <!-- This is the MP-JWT TCK base extension and utility classes --><1>
         <dependency>
             <groupId>org.eclipse.microprofile.jwt</groupId>
             <artifactId>microprofile-jwt-auth-tck</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
-        <!-- Arquillian extension SPI -->
+        <!-- Arquillian extension SPI --><2>
         <dependency>
             <groupId>org.jboss.arquillian.container</groupId>
             <artifactId>arquillian-container-spi</artifactId>
@@ -103,7 +104,7 @@ The
         </dependency>
         <!-- You need to specify a JAX-RS client implementation as the unit
         tests make use of that API, but do not specify and implementation.
-        -->
+        --><3>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-client</artifactId>
@@ -111,45 +112,30 @@ The
         </dependency>
 
         <!-- Specify your container runtime arquillian integration and dependencies -->
-        <dependency>
+        <dependency><4>
             <groupId>MY_GROUP</groupId>
             <artifactId>arquillian-container</artifactId>
             <version>${container-version}</version>
         </dependency>
+        ...
     </dependencies>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.3</version>
-                <executions>
-                    <execution>
-                        <id>attach-javadocs</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
+...
 
 </project>
-```
+----
+<1> org.eclipse.microprofile.jwt:microprofile-jwt-auth-tck is the MP-JWT artifact
+that contains the base `LoadableExtension` and `ApplicationArchiveProcessor` classes,
+as well as the `ITokenParser` harness factory interface and `TokenUtils` class.
+<2> The 2 indicated Arquillian extension SPI dependencies provide the
+`LoadableExtension` and `ApplicationArchiveProcessor` interfaces and dependent
+classes.
+<3> The TCK unit tests make use of the JAX-RS client API, but do not provide an
+implementation, so your TCK harness artifact must specify what implementation to use.
+Here the Resteasy implementation is being specified.
+<4> Lastly, you must specify the property Arquillian container runtime that is
+approriate for you MP-JWT implementation, along with whatever container
+runtime dependencies are required.
 
 == Running Your Implementation With the TCK
 Once you have built and installed your TCK harness artifact, you can run the
@@ -182,7 +168,7 @@ via your implementation. These tests require Arquillian container runtime integr
 your container. You typically provide this via a dependency on an arquillian container artificat, for example,
 Tomcat based containers might include a dependency like:
 
-```
+```maven
 <dependency>
   <groupId>org.jboss.arquillian.container</groupId>
   <artifactId>arquillian-tomcat-embedded-7</artifactId>
@@ -206,3 +192,130 @@ A concrete example is for running with the TCK harness artifiact from the
 https://github.com/MicroProfileJWT/wfswarm-jwt-auth-tck project is:
 
 `mvn -Pcontainer -Dtck.container.groupId=org.wildfly.swarm -Dtck.container.artifactId=jwt-auth-tck -Dtck.container.version=1.0-SNAPSHOT`
+
+== Running the TCK Tests in Your Build
+You can run the TCK tests from within your TCK harness build by including the
+following in your pom.xml:
+
+```maven
+    </dependencies>
+    ...
+        <!-- Include the MP-JWT TCK dependencies -->
+        <dependency>
+            <groupId>org.eclipse.microprofile.jwt</groupId>
+            <artifactId>microprofile-jwt-auth-tck</artifactId>
+            <version>1.0-SNAPSHOT</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.microprofile.jwt</groupId>
+            <artifactId>microprofile-jwt-auth-tck</artifactId>
+            <version>1.0-SNAPSHOT</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+        ...
+            <!-- Run the TCK tests aginst the tck-base-suite.xml -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.20</version>
+                <configuration>
+                    <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                    <suiteXmlFiles>
+                        <suiteXmlFile>tck-base-suite.xml</suiteXmlFile>
+                    </suiteXmlFiles>
+                    <forkCount>1</forkCount>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+```
+
+and then either copy the tck-base-suite.xml file from the TCK source tree into your
+build root, or copy the following and paste if into a tck-base-suite.xml file in
+your build root:
+
+```maven
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+<suite name="microprofile-jwt-auth-BaseTCK" verbose="1" preserve-order="true" configfailurepolicy="continue" >
+
+    <!-- The required base JAX-RS and CDI based tests that all MP-JWT implementations
+    must pass.
+    -->
+    <test name="base-tests">
+        <groups>
+            <run>
+                <include name="arquillian" />
+                <include name="jwt" />
+                <include name="utils" />
+                <include name="jaxrs" />
+                <include name="cdi" />
+                <exclude name="debug" />
+                <exclude name="ejb-optional" />
+                <exclude name="servlet-optional" />
+                <exclude name="jacc-optional" />
+            </run>
+        </groups>
+        <classes>
+            <class name="org.eclipse.microprofile.jwt.tck.parsing.TokenValidationTest" />
+            <class name="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" />
+            <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.PingTest" />
+            <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" />
+        </classes>
+    </test>
+
+</suite>
+```
+
+You then simply run `mvn test` to run the TCK tests. An example of using this approach
+can be found in the https://github.com/MicroProfileJWT/wfswarm-jwt-auth-tck repo.
+Running
+
+```bash
+[wfswarm-jwt-auth-tck 1316]$ mvn -Dswarm.resolver.offline=true test
+[INFO] Scanning for projects...
+[INFO]
+[INFO] ------------------------------------------------------------------------
+[INFO] Building MicroProfile JWT Auth TCK Harness WFSwarm Implementation 1.0-SNAPSHOT
+[INFO] ------------------------------------------------------------------------
+[INFO]
+[INFO] --- maven-resources-plugin:2.6:resources (default-resources) @ jwt-auth-tck ---
+[WARNING] Using platform encoding (UTF-8 actually) to copy filtered resources, i.e. build is platform dependent!
+[INFO] Copying 6 resources
+[INFO]
+[INFO] --- maven-compiler-plugin:3.1:compile (default-compile) @ jwt-auth-tck ---
+[INFO] Nothing to compile - all classes are up to date
+[INFO]
+[INFO] --- maven-resources-plugin:2.6:testResources (default-testResources) @ jwt-auth-tck ---
+[WARNING] Using platform encoding (UTF-8 actually) to copy filtered resources, i.e. build is platform dependent!
+[INFO] skip non existing resourceDirectory /Users/starksm/Dev/JBoss/Microprofile/wfswarm-jwt-auth-tck/src/test/resources
+[INFO]
+[INFO] --- maven-compiler-plugin:3.1:testCompile (default-testCompile) @ jwt-auth-tck ---
+[INFO] No sources to compile
+[INFO]
+[INFO] --- maven-surefire-plugin:2.20:test (default-test) @ jwt-auth-tck ---
+[INFO] No tests to run.
+[INFO]
+[INFO] -------------------------------------------------------
+[INFO]  T E S T S
+[INFO] -------------------------------------------------------
+[INFO] Running TestSuite
+[INFO] Tests run: 19, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 49.95 s - in TestSuite
+[INFO]
+[INFO] Results:
+[INFO]
+[INFO] Tests run: 19, Failures: 0, Errors: 0, Skipped: 0
+[INFO]
+[INFO] ------------------------------------------------------------------------
+[INFO] BUILD SUCCESS
+[INFO] ------------------------------------------------------------------------
+[INFO] Total time: 52.805 s
+[INFO] Finished at: 2017-08-23T17:23:41-07:00
+[INFO] Final Memory: 30M/619M
+[INFO] ------------------------------------------------------------------------
+```

--- a/tck/src/test/java/org/eclipse/microprofile/jwt/tck/TCKConstants.java
+++ b/tck/src/test/java/org/eclipse/microprofile/jwt/tck/TCKConstants.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2016-2017 Contributors to the Eclipse Foundation
+ *
+ *  See the NOTICE file(s) distributed with this work for additional
+ *  information regarding copyright ownership.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  You may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.eclipse.microprofile.jwt.tck;
+
+public class TCKConstants {
+    // TestNG groups
+    public static final String TEST_GROUP_UTILS="utils";
+    public static final String TEST_GROUP_JWT="jwt";
+    public static final String TEST_GROUP_JAXRS="jaxrs";
+    public static final String TEST_GROUP_CDI="cdi";
+    public static final String TEST_GROUP_EJB="ejb-optional";
+    public static final String TEST_GROUP_SERVLET="servlet-optional";
+    public static final String TEST_GROUP_JACC="jacc-optional";
+    public static final String TEST_GROUP_DEBUG="debug";
+
+    private TCKConstants() {}
+}

--- a/tck/src/test/java/org/eclipse/microprofile/jwt/tck/container/ejb/EjbEndpoint.java
+++ b/tck/src/test/java/org/eclipse/microprofile/jwt/tck/container/ejb/EjbEndpoint.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2016-2017 Contributors to the Eclipse Foundation
+ *
+ *  See the NOTICE file(s) distributed with this work for additional
+ *  information regarding copyright ownership.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  You may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.eclipse.microprofile.jwt.tck.container.ejb;
+
+import javax.annotation.security.DenyAll;
+import javax.annotation.security.RolesAllowed;
+import javax.ejb.EJB;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.SecurityContext;
+
+@Path("/endp")
+@DenyAll
+public class EjbEndpoint {
+    @EJB
+    private IService serviceEJB;
+
+    @GET
+    @Path("/getEJBEcho")
+    @RolesAllowed("Echoer")
+    public String getEJBEcho(@Context SecurityContext sec, @QueryParam("input") String input) {
+        return serviceEJB.echo(input);
+    }
+
+    @GET
+    @Path("/getEJBPrincipalClass")
+    @RolesAllowed("Tester")
+    public String getEJBPrincipalClass(@Context SecurityContext sec) {
+        return serviceEJB.getPrincipalClass();
+    }
+
+    @GET
+    @Path("/getEJBSubjectClass")
+    @RolesAllowed("Tester")
+    public String getEJBSubjectClass(@Context SecurityContext sec) throws Exception {
+        return serviceEJB.getSubjectClass();
+    }
+
+}

--- a/tck/src/test/java/org/eclipse/microprofile/jwt/tck/container/ejb/EjbTest.java
+++ b/tck/src/test/java/org/eclipse/microprofile/jwt/tck/container/ejb/EjbTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2016-2017 Contributors to the Eclipse Foundation
+ *
+ *  See the NOTICE file(s) distributed with this work for additional
+ *  information regarding copyright ownership.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  You may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.eclipse.microprofile.jwt.tck.container.ejb;
+
+import org.eclipse.microprofile.jwt.JsonWebToken;
+import org.eclipse.microprofile.jwt.tck.TCKConstants;
+import org.eclipse.microprofile.jwt.tck.container.jaxrs.TCKApplication;
+import org.eclipse.microprofile.jwt.tck.util.TokenUtils;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.Response;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
+
+/**
+ *
+ */
+public class EjbTest extends Arquillian {
+
+    /**
+     * The test generated JWT token string
+     */
+    private static String token;
+    /**
+     * The base URL for the container under test
+     */
+    @ArquillianResource
+    private URL baseURL;
+
+    /**
+     * Create a CDI aware base web application archive
+     * @return the base base web application archive
+     * @throws IOException - on resource failure
+     */
+    @Deployment(testable=true)
+    public static WebArchive createDeployment() throws IOException {
+        URL publicKey = EjbTest.class.getResource("/publicKey.pem");
+        WebArchive webArchive = ShrinkWrap
+            .create(WebArchive.class, "EjbTest.war")
+            .addAsResource(publicKey, "/publicKey.pem")
+            .addClass(EjbEndpoint.class)
+            .addClass(TCKApplication.class)
+            .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+            .addAsWebInfResource("WEB-INF/web.xml", "web.xml")
+            ;
+        System.out.printf("WebArchive: %s\n", webArchive.toString(true));
+        return webArchive;
+    }
+
+    @BeforeClass(alwaysRun = true)
+    public static void generateToken() throws Exception {
+        token = TokenUtils.generateTokenString("/RolesEndpoint.json");
+    }
+
+    @RunAsClient
+    @Test(groups = TCKConstants.TEST_GROUP_EJB,
+        description = "Validate a request with MP-JWT to a secured method propagates to a secured ejb method")
+    public void callEjbEcho() throws Exception {
+        String uri = baseURL.toExternalForm() + "/endp/getEJBEcho";
+        WebTarget echoEndpointTarget = ClientBuilder.newClient()
+            .target(uri)
+            ;
+        Response response = echoEndpointTarget.request(TEXT_PLAIN).header(HttpHeaders.AUTHORIZATION, "Bearer "+token).get();
+        Assert.assertEquals(HttpURLConnection.HTTP_OK, response.getStatus());
+        String reply = response.readEntity(String.class);
+        System.out.println(reply);
+    }
+
+    @RunAsClient
+    @Test(groups = TCKConstants.TEST_GROUP_EJB,
+        description = "Validate a request with MP-JWT PolicyContext.getContext() Subject has a JsonWebToken")
+    public void getSubjectClass() throws Exception {
+        String uri = baseURL.toExternalForm() + "/endp/getEJBSubjectClass";
+        WebTarget echoEndpointTarget = ClientBuilder.newClient()
+            .target(uri)
+            ;
+        Response response = echoEndpointTarget.request(TEXT_PLAIN).header(HttpHeaders.AUTHORIZATION, "Bearer "+token).get();
+        Assert.assertEquals(HttpURLConnection.HTTP_OK, response.getStatus());
+        String reply = response.readEntity(String.class);
+        System.out.println(reply);
+    }
+
+    @RunAsClient
+    @Test(groups = TCKConstants.TEST_GROUP_EJB,
+        description = "Validate a request with MP-JWT SecurityContext.getUserPrincipal() is a JsonWebToken")
+    public void testEJBPrincipalClass() throws Exception {
+        String uri = baseURL.toExternalForm() + "/endp/getEJBPrincipalClass";
+        WebTarget echoEndpointTarget = ClientBuilder.newClient()
+            .target(uri)
+            ;
+        Response response = echoEndpointTarget.request(TEXT_PLAIN).header(HttpHeaders.AUTHORIZATION, "Bearer "+token).get();
+        Assert.assertEquals(HttpURLConnection.HTTP_OK, response.getStatus());
+        String reply = response.readEntity(String.class);
+        String[] ifaces = reply.split(",");
+        boolean hasJsonWebToken = false;
+        for(String iface : ifaces) {
+            hasJsonWebToken |= iface.equals(JsonWebToken.class.getTypeName());
+        }
+        Assert.assertTrue(hasJsonWebToken, "EJB PrincipalClass has JsonWebToken interface");
+    }
+
+}

--- a/tck/src/test/java/org/eclipse/microprofile/jwt/tck/container/ejb/IService.java
+++ b/tck/src/test/java/org/eclipse/microprofile/jwt/tck/container/ejb/IService.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2016-2017 Contributors to the Eclipse Foundation
+ *
+ *  See the NOTICE file(s) distributed with this work for additional
+ *  information regarding copyright ownership.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  You may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.eclipse.microprofile.jwt.tck.container.ejb;
+
+import javax.ejb.Local;
+
+@Local
+public interface IService {
+    public String echo(String input);
+    public String getPrincipalClass();
+    public String getSubjectClass() throws Exception;
+}

--- a/tck/src/test/java/org/eclipse/microprofile/jwt/tck/container/ejb/ServiceEJB.java
+++ b/tck/src/test/java/org/eclipse/microprofile/jwt/tck/container/ejb/ServiceEJB.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2016-2017 Contributors to the Eclipse Foundation
+ *
+ *  See the NOTICE file(s) distributed with this work for additional
+ *  information regarding copyright ownership.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  You may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.eclipse.microprofile.jwt.tck.container.ejb;
+
+import java.security.Principal;
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.annotation.Resource;
+import javax.annotation.security.RolesAllowed;
+import javax.ejb.SessionContext;
+import javax.ejb.Stateless;
+import javax.security.auth.Subject;
+import javax.security.jacc.PolicyContext;
+
+import org.eclipse.microprofile.jwt.JsonWebToken;
+
+@Stateless
+public class ServiceEJB implements IService {
+
+    @Resource
+    private SessionContext ctx;
+
+    @RolesAllowed("Echoer")
+    public String echo(String input) {
+        Principal user = ctx.getCallerPrincipal();
+        return String.format("ServiceEJB, input=%s, user=%s", input, user.getName());
+    }
+
+    @RolesAllowed("Tester")
+    public String getPrincipalClass() {
+        Principal user = ctx.getCallerPrincipal();
+        System.out.printf("ServiceEJB.getPrincipalClass, user=%s, class=%s\n", user.getName(), user.getClass());
+        HashSet<Class> interfaces = new HashSet<>();
+        Class current = user.getClass();
+        while(current.equals(Object.class) == false) {
+            Class[] tmp = current.getInterfaces();
+            for(Class c : tmp) {
+                interfaces.add(c);
+            }
+            current = current.getSuperclass();
+        }
+        StringBuilder tmp = new StringBuilder();
+        for(Class iface : interfaces) {
+            tmp.append(iface.getTypeName());
+            tmp.append(',');
+        }
+        tmp.setLength(tmp.length()-1);
+        return tmp.toString();
+    }
+    @RolesAllowed("Tester")
+    public String getSubjectClass() throws Exception {
+        Subject subject = (Subject) PolicyContext.getContext("javax.security.auth.Subject.container");
+        System.out.printf("ServiceEJB.getSubjectClass, subject=%s\n", subject);
+        Set<? extends Principal> principalSet = subject.getPrincipals(JsonWebToken.class);
+        if (principalSet.size() > 0) {
+            return "subject.getPrincipals(JsonWebToken.class) ok";
+        }
+        throw new IllegalStateException("subject.getPrincipals(JsonWebToken.class) == 0");
+    }
+}

--- a/tck/src/test/java/org/eclipse/microprofile/jwt/tck/container/jacc/SubjectEndpoint.java
+++ b/tck/src/test/java/org/eclipse/microprofile/jwt/tck/container/jacc/SubjectEndpoint.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2016-2017 Contributors to the Eclipse Foundation
+ *
+ *  See the NOTICE file(s) distributed with this work for additional
+ *  information regarding copyright ownership.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  You may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.eclipse.microprofile.jwt.tck.container.jacc;
+
+import org.eclipse.microprofile.jwt.JsonWebToken;
+
+import javax.annotation.security.DenyAll;
+import javax.annotation.security.RolesAllowed;
+import javax.security.auth.Subject;
+import javax.security.jacc.PolicyContext;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.SecurityContext;
+import java.security.Principal;
+import java.util.Set;
+
+@Path("/endp")
+@DenyAll
+public class SubjectEndpoint {
+    @GET
+    @Path("/getSubjectClass")
+    @RolesAllowed("Tester")
+    public String getSubjectClass(@Context SecurityContext sec) throws Exception {
+        Subject subject = (Subject) PolicyContext.getContext("javax.security.auth.Subject.container");
+        Set<? extends Principal> principalSet = subject.getPrincipals(JsonWebToken.class);
+        if (principalSet.size() > 0) {
+            return "subject.getPrincipals(JWTPrincipal.class) ok";
+        }
+        throw new IllegalStateException("subject.getPrincipals(JWTPrincipal.class) == 0");
+    }
+}

--- a/tck/src/test/java/org/eclipse/microprofile/jwt/tck/container/jaxrs/RolesAllowedTest.java
+++ b/tck/src/test/java/org/eclipse/microprofile/jwt/tck/container/jaxrs/RolesAllowedTest.java
@@ -19,20 +19,20 @@
  */
 package org.eclipse.microprofile.jwt.tck.container.jaxrs;
 
+import org.eclipse.microprofile.jwt.Claims;
 import org.eclipse.microprofile.jwt.JsonWebToken;
+import org.eclipse.microprofile.jwt.tck.TCKConstants;
 import org.eclipse.microprofile.jwt.tck.util.TokenUtils;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
 
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.WebTarget;
@@ -43,20 +43,27 @@ import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.Base64;
+import java.util.HashMap;
 import java.util.HashSet;
 
 import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
+import static org.eclipse.microprofile.jwt.tck.TCKConstants.TEST_GROUP_CDI;
+import static org.eclipse.microprofile.jwt.tck.TCKConstants.TEST_GROUP_JAXRS;
 
 /**
  * Tests of the MP-JWT auth method as expected by the MP-JWT RBAC 1.0 spec
  */
-@RunWith(Arquillian.class)
-public class RolesAllowedTest {
+public class RolesAllowedTest extends Arquillian {
 
     /**
      * The test generated JWT token string
      */
     private static String token;
+    // Time claims in the token
+    private static Long iatClaim;
+    private static Long authTimeClaim;
+    private static Long expClaim;
+
     /**
      * The base URL for the container under test
      */
@@ -83,11 +90,16 @@ public class RolesAllowedTest {
         return webArchive;
     }
 
-    @BeforeClass
+    @BeforeClass(alwaysRun=true)
     public static void generateToken() throws Exception {
-        token = TokenUtils.generateTokenString("/RolesEndpoint.json");
+        HashMap<String, Long> timeClaims = new HashMap<>();
+        token = TokenUtils.generateTokenString("/RolesEndpoint.json", null, timeClaims);
+        iatClaim = timeClaims.get(Claims.iat.name());
+        authTimeClaim = timeClaims.get(Claims.auth_time.name());
+        expClaim = timeClaims.get(Claims.exp.name());
     }
-    @Test
+
+    @Test(groups = TEST_GROUP_JAXRS, description = "Validate a request with no token fails with 403")
     public void callEchoNoAuth() throws Exception {
         String uri = baseURL.toExternalForm() + "/endp/echo";
         WebTarget echoEndpointTarget = ClientBuilder.newClient()
@@ -95,11 +107,11 @@ public class RolesAllowedTest {
             .queryParam("input", "hello")
             ;
         Response response = echoEndpointTarget.request(TEXT_PLAIN).get();
-        Assert.assertEquals(HttpURLConnection.HTTP_UNAUTHORIZED, response.getStatus());
+        Assert.assertEquals(response.getStatus(), HttpURLConnection.HTTP_UNAUTHORIZED);
     }
 
     @RunAsClient
-    @Test
+    @Test(groups = TEST_GROUP_JAXRS, description = "Validate a request with expired token fails with 403")
     public void callEchoExpiredToken() throws Exception {
         HashSet<TokenUtils.InvalidClaims> invalidFields = new HashSet<>();
         invalidFields.add(TokenUtils.InvalidClaims.EXP);
@@ -112,7 +124,7 @@ public class RolesAllowedTest {
             .queryParam("input", "hello")
             ;
         Response response = echoEndpointTarget.request(TEXT_PLAIN).header(HttpHeaders.AUTHORIZATION, "Bearer "+token).get();
-        Assert.assertEquals(HttpURLConnection.HTTP_UNAUTHORIZED, response.getStatus());
+        Assert.assertEquals(response.getStatus(), HttpURLConnection.HTTP_UNAUTHORIZED);
         String reply = response.readEntity(String.class);
     }
 
@@ -121,8 +133,7 @@ public class RolesAllowedTest {
      * @throws Exception
      */
     @RunAsClient
-    @Test
-    @Ignore
+    @Test(groups = TCKConstants.TEST_GROUP_DEBUG, description = "Internal debugging test to test BASIC auth behavior")
     public void callEchoBASIC() throws Exception {
         byte[] tokenb = Base64.getEncoder().encode("jdoe@example.com:password".getBytes());
         String token = new String(tokenb);
@@ -136,11 +147,11 @@ public class RolesAllowedTest {
         Response response = echoEndpointTarget.request(TEXT_PLAIN).header(HttpHeaders.AUTHORIZATION, "BASIC "+token).get();
         Assert.assertEquals(HttpURLConnection.HTTP_OK, response.getStatus());
         String reply = response.readEntity(String.class);
-        Assert.assertEquals("hello, user=jdoe@example.com", reply);
+        Assert.assertEquals(reply, "hello, user=jdoe@example.com");
     }
 
     @RunAsClient
-    @Test(timeout = 1000000)
+    @Test(groups = TEST_GROUP_JAXRS, description = "Validate a request with MP-JWT succeeds")
     public void callEcho() throws Exception {
         System.out.printf("jwt: %s\n", token);
 
@@ -152,11 +163,11 @@ public class RolesAllowedTest {
         Response response = echoEndpointTarget.request(TEXT_PLAIN).header(HttpHeaders.AUTHORIZATION, "Bearer "+token).get();
         Assert.assertEquals(HttpURLConnection.HTTP_OK, response.getStatus());
         String reply = response.readEntity(String.class);
-        Assert.assertEquals("hello, user=jdoe@example.com", reply);
+        Assert.assertEquals(reply, "hello, user=jdoe@example.com");
     }
 
     @RunAsClient
-    @Test(timeout = 1000000)
+    @Test(groups = TEST_GROUP_JAXRS, description = "Validate a request with MP-JWT but no associated role fails with 403")
     public void callEcho2() throws Exception {
         System.out.printf("jwt: %s\n", token);
 
@@ -167,38 +178,26 @@ public class RolesAllowedTest {
             ;
         Response response = echoEndpointTarget.request(TEXT_PLAIN).header(HttpHeaders.AUTHORIZATION, "Bearer "+token).get();
         String reply = response.readEntity(String.class);
-        Assert.assertEquals(HttpURLConnection.HTTP_FORBIDDEN, response.getStatus());
+        Assert.assertEquals(response.getStatus(), HttpURLConnection.HTTP_FORBIDDEN);
     }
 
     @RunAsClient
-    @Test
+    @Test(groups = TEST_GROUP_JAXRS,
+        description = "Validate a request with MP-JWT SecurityContext.getUserPrincipal() is a JsonWebToken")
     public void getPrincipalClass() throws Exception {
         String uri = baseURL.toExternalForm() + "/endp/getPrincipalClass";
         WebTarget echoEndpointTarget = ClientBuilder.newClient()
             .target(uri)
             ;
         Response response = echoEndpointTarget.request(TEXT_PLAIN).header(HttpHeaders.AUTHORIZATION, "Bearer "+token).get();
-        Assert.assertEquals(HttpURLConnection.HTTP_OK, response.getStatus());
+        Assert.assertEquals(response.getStatus(), HttpURLConnection.HTTP_OK);
         String reply = response.readEntity(String.class);
         String[] ifaces = reply.split(",");
-        boolean hasJWTPrincipal = false;
+        boolean hasJsonWebToken = false;
         for(String iface : ifaces) {
-            hasJWTPrincipal |= iface.equals(JsonWebToken.class.getTypeName());
+            hasJsonWebToken |= iface.equals(JsonWebToken.class.getTypeName());
         }
-        Assert.assertTrue("PrincipalClass has JWTPrincipal interface", hasJWTPrincipal);
-    }
-
-    @RunAsClient
-    @Test
-    public void getSubjectClass() throws Exception {
-        String uri = baseURL.toExternalForm() + "/endp/getSubjectClass";
-        WebTarget echoEndpointTarget = ClientBuilder.newClient()
-            .target(uri)
-            ;
-        Response response = echoEndpointTarget.request(TEXT_PLAIN).header(HttpHeaders.AUTHORIZATION, "Bearer "+token).get();
-        Assert.assertEquals(HttpURLConnection.HTTP_OK, response.getStatus());
-        String reply = response.readEntity(String.class);
-        System.out.println(reply);
+        Assert.assertTrue(hasJsonWebToken, "PrincipalClass has JsonWebToken interface");
     }
 
     /**
@@ -206,20 +205,102 @@ public class RolesAllowedTest {
      * application declared role.
      */
     @RunAsClient
-    @Test
+    @Test(groups = TEST_GROUP_JAXRS,
+        description = "Validate a request without an MP-JWT to endpoint requiring role mapping has HTTP_OK")
     public void testNeedsGroup1Mapping() {
         String uri = baseURL.toExternalForm() + "/endp/needsGroup1Mapping";
         WebTarget echoEndpointTarget = ClientBuilder.newClient()
             .target(uri)
             ;
         Response response = echoEndpointTarget.request(TEXT_PLAIN).header(HttpHeaders.AUTHORIZATION, "Bearer "+token).get();
-        Assert.assertEquals(HttpURLConnection.HTTP_OK, response.getStatus());
+        Assert.assertEquals(response.getStatus(), HttpURLConnection.HTTP_OK);
         String reply = response.readEntity(String.class);
         System.out.println(reply);
     }
 
+    @Test(groups = TEST_GROUP_CDI,
+        description = "")
+    public void getInjectedPrincipal() throws Exception {
+        String uri = baseURL.toExternalForm() + "/endp/getInjectedPrincipal";
+        WebTarget echoEndpointTarget = ClientBuilder.newClient()
+            .target(uri)
+            ;
+        Response response = echoEndpointTarget.request(TEXT_PLAIN).header(HttpHeaders.AUTHORIZATION, "Bearer "+token).get();
+        Assert.assertEquals(HttpURLConnection.HTTP_OK, response.getStatus());
+        String reply = response.readEntity(String.class);
+        String[] ifaces = reply.split(",");
+        boolean hasJsonWebToken = false;
+        for(String iface : ifaces) {
+            hasJsonWebToken |= iface.equals(JsonWebToken.class.getTypeName());
+        }
+        Assert.assertTrue(hasJsonWebToken, "PrincipalClass has JsonWebToken interface");
+    }
+
+    @Test(groups = TEST_GROUP_CDI,
+        description = "")
+    public void getInjectedClaims() throws Exception {
+        String uri = baseURL.toExternalForm() + "/endp/getInjectedClaims";
+        WebTarget echoEndpointTarget = ClientBuilder.newClient()
+            .target(uri)
+            .queryParam(Claims.iss.name(), "https://server.example.com")
+            .queryParam(Claims.jti.name(), "a-123")
+            .queryParam(Claims.aud.name(), "s6BhdRkqt3")
+            .queryParam(Claims.sub.name(), "24400320")
+            .queryParam(Claims.raw_token.name(), token)
+            .queryParam(Claims.iat.name(), iatClaim)
+            .queryParam(Claims.auth_time.name(), authTimeClaim)
+            ;
+        Response response = echoEndpointTarget.request(TEXT_PLAIN).header(HttpHeaders.AUTHORIZATION, "Bearer "+token).get();
+        Assert.assertEquals(HttpURLConnection.HTTP_OK, response.getStatus());
+        String reply = response.readEntity(String.class);
+        System.out.println(reply);
+        // Validate the expected injection tests
+        Assert.assertTrue(reply.contains("iss PASS"));
+        Assert.assertTrue(reply.contains("jti PASS"));
+        Assert.assertTrue(reply.contains("jti-Optional PASS"));
+        Assert.assertTrue(reply.contains("jti-Provider PASS"));
+        Assert.assertTrue(reply.contains("aud PASS"));
+        Assert.assertTrue(reply.contains("iat PASS"));
+        Assert.assertTrue(reply.contains("iat-Dupe PASS"));
+        Assert.assertTrue(reply.contains("sub-Optional PASS"));
+        Assert.assertTrue(reply.contains("auth_time PASS"));
+        Assert.assertTrue(reply.contains("raw_token PASS"));
+        Assert.assertTrue(reply.contains("custom-missing PASS"));
+
+        // A second request to validate the request scope of injected values
+        HashMap<String, Long> timeClaims = new HashMap<>();
+        String token2 = TokenUtils.generateTokenString("/RolesEndpoint2.json", null, timeClaims);
+        Long iatClaim2 = timeClaims.get(Claims.iat.name());
+        Long authTimeClaim2 = timeClaims.get(Claims.auth_time.name());
+        WebTarget echoEndpointTarget2 = ClientBuilder.newClient()
+            .target(uri)
+            .queryParam(Claims.iss.name(), "https://server.example.com")
+            .queryParam(Claims.jti.name(), "a-123.2")
+            .queryParam(Claims.aud.name(), "s6BhdRkqt3")
+            .queryParam(Claims.sub.name(), "24400320#2")
+            .queryParam(Claims.raw_token.name(), token2)
+            .queryParam(Claims.iat.name(), iatClaim2)
+            .queryParam(Claims.auth_time.name(), authTimeClaim2)
+            ;
+        Response response2 = echoEndpointTarget2.request(TEXT_PLAIN).header(HttpHeaders.AUTHORIZATION, "Bearer "+token2).get();
+        Assert.assertEquals(HttpURLConnection.HTTP_OK, response2.getStatus());
+        reply = response2.readEntity(String.class);
+        System.out.println(reply);
+        Assert.assertTrue(reply.contains("iss PASS"));
+        Assert.assertTrue(reply.contains("jti PASS"));
+        Assert.assertTrue(reply.contains("jti-Optional PASS"));
+        Assert.assertTrue(reply.contains("jti-Provider PASS"));
+        Assert.assertTrue(reply.contains("aud PASS"));
+        Assert.assertTrue(reply.contains("iat PASS"));
+        Assert.assertTrue(reply.contains("iat-Dupe PASS"));
+        Assert.assertTrue(reply.contains("sub-Optional PASS"));
+        Assert.assertTrue(reply.contains("auth_time PASS"));
+        Assert.assertTrue(reply.contains("raw_token PASS"));
+        Assert.assertTrue(reply.contains("custom-missing PASS"));
+    }
+
     @RunAsClient
-    @Test
+    @Test(groups = TEST_GROUP_JAXRS, description = "Validate a request without an MP-JWT to unsecured endpoint has HTTP_OK")
     public void callHeartbeat() throws Exception {
         String uri = baseURL.toExternalForm() + "/endp/heartbeat";
         WebTarget echoEndpointTarget = ClientBuilder.newClient()
@@ -227,7 +308,7 @@ public class RolesAllowedTest {
             .queryParam("input", "hello")
             ;
         Response response = echoEndpointTarget.request(TEXT_PLAIN).get();
-        Assert.assertEquals(HttpURLConnection.HTTP_OK, response.getStatus());
-        Assert.assertTrue("Heartbeat:", response.readEntity(String.class).startsWith("Heartbeat:"));
+        Assert.assertEquals(response.getStatus(), HttpURLConnection.HTTP_OK);
+        Assert.assertTrue(response.readEntity(String.class).startsWith("Heartbeat:"), "Saw Heartbeat: ...");
     }
 }

--- a/tck/src/test/java/org/eclipse/microprofile/jwt/tck/container/jaxrs/RolesEndpoint.java
+++ b/tck/src/test/java/org/eclipse/microprofile/jwt/tck/container/jaxrs/RolesEndpoint.java
@@ -22,6 +22,7 @@ package org.eclipse.microprofile.jwt.tck.container.jaxrs;
 
 import org.eclipse.microprofile.jwt.Claim;
 import org.eclipse.microprofile.jwt.ClaimValue;
+import org.eclipse.microprofile.jwt.Claims;
 import org.eclipse.microprofile.jwt.JsonWebToken;
 
 import javax.annotation.security.DenyAll;
@@ -36,21 +37,39 @@ import javax.ws.rs.core.SecurityContext;
 import java.security.Principal;
 import java.util.Date;
 import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
 
 @Path("/endp")
 @DenyAll
 public class RolesEndpoint {
 
     @Inject
-    private JsonWebToken callerPrincipal;
-
+    private JsonWebToken jwtPrincipal;
+    @Inject
     @Claim("raw_token")
+    private ClaimValue<String> rawToken;
     @Inject
-    private ClaimValue<String> token;
-
     @Claim("iss")
-    @Inject
     private ClaimValue<String> issuer;
+    @Inject
+    @Claim("jti")
+    private ClaimValue<String> jti;
+    @Inject
+    @Claim("aud")
+    private ClaimValue<Set<String>> aud;
+    @Inject
+    @Claim("roles")
+    private ClaimValue<String[]> roles;
+    @Inject
+    @Claim("iat")
+    private ClaimValue<Long> issuedAt;
+    @Inject
+    @Claim("sub")
+    private ClaimValue<Optional<String>> optSubject;
+    @Inject
+    @Claim("auth_time")
+    private ClaimValue<Optional<Long>> authTime;
 
     @GET
     @Path("/echo")
@@ -114,19 +133,7 @@ public class RolesEndpoint {
         return "serviceEJB.getSubjectClass()";
     }
 
-    @GET
-    @Path("/getSubjectClass")
-    @RolesAllowed("Tester")
-    public String getSubjectClass(@Context SecurityContext sec) throws Exception {
-        /*
-        Subject subject = (Subject) PolicyContext.getContext("javax.security.auth.Subject.container");
-        Set<? extends Principal> principalSet = subject.getPrincipals(JWTPrincipal.class);
-        if (principalSet.size() > 0)
-            return "subject.getPrincipals(JWTPrincipal.class) ok";
-        throw new IllegalStateException("subject.getPrincipals(JWTPrincipal.class) == 0");
-        */
-        return "subject.getPrincipals(JWTPrincipal.class) ok";
-    }
+
 
     /**
      * This
@@ -139,6 +146,122 @@ public class RolesEndpoint {
         Principal user = sec.getUserPrincipal();
         sec.isUserInRole("group1");
         return user.getName();
+    }
+
+    @GET
+    @Path("/getInjectedPrincipal")
+    public String getInjectedPrincipal(@Context SecurityContext sec) {
+        HashSet<Class> interfaces = new HashSet<>();
+        Class current = jwtPrincipal.getClass();
+        while(current.equals(Object.class) == false) {
+            Class[] tmp = current.getInterfaces();
+            for(Class c : tmp) {
+                interfaces.add(c);
+            }
+            current = current.getSuperclass();
+        }
+        StringBuilder tmp = new StringBuilder();
+        for(Class iface : interfaces) {
+            tmp.append(iface.getTypeName());
+            tmp.append(',');
+        }
+        tmp.setLength(tmp.length()-1);
+        return tmp.toString();
+    }
+
+    /**
+     * Verify that values exist and that types match the corresponding Claims enum
+     * @return a series of pass/fail statements regarding the check for each injected claim
+     */
+    @GET
+    @Path("/getInjectedClaims")
+    public String getInjectedIssuer(@QueryParam("iss") String iss,
+                                    @QueryParam("raw_token") String rt,
+                                    @QueryParam("jti") String jwtID,
+                                    @QueryParam("aud") String audience,
+                                    @QueryParam("iat") Long iat,
+                                    @QueryParam("sub") String subject,
+                                    @QueryParam("auth_time") Long authTime) {
+        StringBuilder tmp = new StringBuilder("getInjectedClaims\n");
+        // iss
+        String issValue = issuer.getValue();
+        if(issValue == null || issValue.length() == 0) {
+            tmp.append(Claims.iss.name()+"value is null or empty\n");
+        }
+        else if(issValue.equals(iss)) {
+            tmp.append(Claims.iss.name()+" PASS\n");
+        }
+        else {
+            tmp.append(Claims.iss.name()+" FAIL\n");
+        }
+        // raw_token
+        String rawTokenValue = rawToken.getValue();
+        if(rawTokenValue == null || rawTokenValue.length() == 0) {
+            tmp.append(Claims.raw_token.name()+" value is null or empty\n");
+        }
+        else if(rawTokenValue.equals(rt)) {
+            tmp.append(Claims.raw_token.name()+" PASS\n");
+        }
+        else {
+            tmp.append(Claims.raw_token.name()+" FAIL\n");
+        }
+        // jti
+        String jtiValue = jti.getValue();
+        if(jtiValue == null || jtiValue.length() == 0) {
+            tmp.append(Claims.jti.name()+" value is null or empty\n");
+        }
+        else if(jtiValue.equals(jwtID)) {
+            tmp.append(Claims.jti.name()+" PASS\n");
+        }
+        else {
+            tmp.append(Claims.jti.name()+" FAIL\n");
+        }
+        // aud
+        Set<String> audValue = aud.getValue();
+        if(audValue == null || audValue.size() == 0) {
+            tmp.append(Claims.aud.name()+" value is null or empty\n");
+        }
+        else if(audValue.contains(audience)) {
+            tmp.append(Claims.aud.name()+" PASS\n");
+        }
+        else {
+            tmp.append(Claims.aud.name()+" FAIL\n");
+        }
+        // iat
+        Long iatValue = issuedAt.getValue();
+        if(iatValue == null || iatValue.intValue() == 0) {
+            tmp.append(Claims.iat.name()+" value is null or zero\n");
+        }
+        else if(iatValue.equals(iat)) {
+            tmp.append(Claims.iat.name()+" PASS\n");
+        }
+        else {
+            tmp.append(Claims.iat.name()+" FAIL\n");
+        }
+        // sub
+        Optional<String> optSubValue = optSubject.getValue();
+        if(optSubValue == null || !optSubValue.isPresent()) {
+            tmp.append(Claims.sub.name()+" value is null or missing\n");
+        }
+        else if(optSubValue.get().equals(subject)) {
+            tmp.append(Claims.sub.name()+" PASS\n");
+        }
+        else {
+            tmp.append(Claims.sub.name()+" FAIL\n");
+        }
+        // auth_time
+        Optional<Long> optAuthTimeValue = this.authTime.getValue();
+        if(optAuthTimeValue == null || !optAuthTimeValue.isPresent()) {
+            tmp.append(Claims.auth_time.name()+" value is null or missing\n");
+        }
+        else if(optAuthTimeValue.get().equals(authTime)) {
+            tmp.append(Claims.auth_time.name()+" PASS\n");
+        }
+        else {
+            tmp.append(Claims.auth_time.name()+" FAIL\n");
+        }
+
+        return tmp.toString();
     }
 
     @GET

--- a/tck/src/test/java/org/eclipse/microprofile/jwt/tck/container/servlet/ServiceServlet.java
+++ b/tck/src/test/java/org/eclipse/microprofile/jwt/tck/container/servlet/ServiceServlet.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2016-2017 Contributors to the Eclipse Foundation
+ *
+ *  See the NOTICE file(s) distributed with this work for additional
+ *  information regarding copyright ownership.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  You may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.eclipse.microprofile.jwt.tck.container.servlet;
+
+import java.io.IOException;
+import java.security.Principal;
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.ejb.EJB;
+import javax.security.auth.Subject;
+import javax.security.jacc.PolicyContext;
+import javax.security.jacc.PolicyContextException;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.HttpConstraint;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.eclipse.microprofile.jwt.JsonWebToken;
+import org.eclipse.microprofile.jwt.tck.container.ejb.IService;
+
+@HttpConstraint(rolesAllowed={"Tester"})
+@WebServlet("/ServiceServlet/*")
+public class ServiceServlet extends HttpServlet {
+    @EJB
+    private IService serviceEJB;
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        Principal user = req.getUserPrincipal();
+        String pathInfo = req.getPathInfo();
+        System.out.printf("pathInfo=%s\n", pathInfo);
+
+        String result = "";
+        if(pathInfo.endsWith("/getSubject")) {
+            System.out.printf("Calling getSubject\n");
+            result = getSubject(resp);
+        }
+        else {
+            System.out.printf("Calling getPrincipalClass\n");
+            result = getPrincipalClass(user);
+        }
+        resp.getWriter().write(result);
+    }
+    private String getPrincipalClass(Principal user) {
+        HashSet<Class> interfaces = new HashSet<>();
+        Class current = user.getClass();
+        while(current.equals(Object.class) == false) {
+            Class[] tmp = current.getInterfaces();
+            for(Class c : tmp) {
+                interfaces.add(c);
+            }
+            current = current.getSuperclass();
+        }
+        StringBuilder tmp = new StringBuilder();
+        for(Class iface : interfaces) {
+            tmp.append(iface.getTypeName());
+            tmp.append(',');
+        }
+        tmp.setLength(tmp.length()-1);
+        return tmp.toString();
+    }
+    private String getSubject(HttpServletResponse response) throws IOException {
+        try {
+            Subject subject = (Subject) PolicyContext.getContext("javax.security.auth.Subject.container");
+            Set<? extends Principal> principalSet = subject.getPrincipals(JsonWebToken.class);
+            if(principalSet.size() > 0) {
+                return "subject.getPrincipals(JsonWebToken.class) ok";
+            }
+            response.sendError(500, "subject.getPrincipals(JsonWebToken.class) == 0");
+        }
+        catch (PolicyContextException e) {
+            e.printStackTrace();
+            response.sendError(500, e.getMessage());
+        }
+        throw new IllegalStateException("subject.getPrincipals(JsonWebToken.class) == 0");
+    }
+    private String callEJB(HttpServletResponse response) throws IOException {
+        return "";
+    }
+}

--- a/tck/src/test/java/org/eclipse/microprofile/jwt/tck/container/servlet/ServletTest.java
+++ b/tck/src/test/java/org/eclipse/microprofile/jwt/tck/container/servlet/ServletTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2016-2017 Contributors to the Eclipse Foundation
+ *
+ *  See the NOTICE file(s) distributed with this work for additional
+ *  information regarding copyright ownership.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  You may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.eclipse.microprofile.jwt.tck.container.servlet;
+
+import org.eclipse.microprofile.jwt.JsonWebToken;
+import org.eclipse.microprofile.jwt.tck.TCKConstants;
+import org.eclipse.microprofile.jwt.tck.container.ejb.EjbEndpoint;
+import org.eclipse.microprofile.jwt.tck.container.jaxrs.TCKApplication;
+import org.eclipse.microprofile.jwt.tck.util.TokenUtils;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.Response;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
+
+/**
+ *
+ */
+public class ServletTest extends Arquillian {
+
+    /**
+     * The test generated JWT token string
+     */
+    private static String token;
+    /**
+     * The base URL for the container under test
+     */
+    @ArquillianResource
+    private URL baseURL;
+
+    /**
+     * Create a CDI aware base web application archive
+     * @return the base base web application archive
+     * @throws IOException - on resource failure
+     */
+    @Deployment(testable=true)
+    public static WebArchive createDeployment() throws IOException {
+        URL publicKey = ServletTest.class.getResource("/publicKey.pem");
+        WebArchive webArchive = ShrinkWrap
+            .create(WebArchive.class, "ServletTest.war")
+            .addAsResource(publicKey, "/publicKey.pem")
+            .addClass(EjbEndpoint.class)
+            .addClass(ServiceServlet.class)
+            .addClass(TCKApplication.class)
+            .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+            .addAsWebInfResource("WEB-INF/web.xml", "web.xml")
+            ;
+        System.out.printf("WebArchive: %s\n", webArchive.toString(true));
+        return webArchive;
+    }
+
+    @BeforeClass(alwaysRun = true)
+    public static void generateToken() throws Exception {
+        token = TokenUtils.generateTokenString("/RolesEndpoint.json");
+    }
+
+    @RunAsClient
+    @Test(groups = TCKConstants.TEST_GROUP_SERVLET,
+        description = "Validate a request with MP-JWT SecurityContext.getUserPrincipal() is a JsonWebToken")
+    public void getServletPrincipalClass() throws Exception {
+        String uri = baseURL.toExternalForm() + "/ServiceServlet/getPrincipalClass";
+        WebTarget echoEndpointTarget = ClientBuilder.newClient()
+            .target(uri)
+            ;
+        Response response = echoEndpointTarget.request(TEXT_PLAIN).header(HttpHeaders.AUTHORIZATION, "Bearer "+token).get();
+        Assert.assertEquals(HttpURLConnection.HTTP_OK, response.getStatus());
+        String reply = response.readEntity(String.class);
+        String[] ifaces = reply.split(",");
+        boolean hasJsonWebToken = false;
+        for(String iface : ifaces) {
+            hasJsonWebToken |= iface.equals(JsonWebToken.class.getTypeName());
+        }
+        Assert.assertTrue(hasJsonWebToken, "PrincipalClass has JsonWebToken interface");
+    }
+    @RunAsClient
+    @Test(groups = TCKConstants.TEST_GROUP_SERVLET,
+        description = "Validate a request with MP-JWT PolicyContext.getContext() Subject has a JsonWebToken")
+    public void getServletSubjectClass() throws Exception {
+        String uri = baseURL.toExternalForm() + "/ServiceServlet/getSubject";
+        WebTarget echoEndpointTarget = ClientBuilder.newClient()
+            .target(uri)
+            ;
+        Response response = echoEndpointTarget.request(TEXT_PLAIN).header(HttpHeaders.AUTHORIZATION, "Bearer "+token).get();
+        Assert.assertEquals(HttpURLConnection.HTTP_OK, response.getStatus());
+        String reply = response.readEntity(String.class);
+        System.out.println(reply);
+    }
+}

--- a/tck/src/test/java/org/eclipse/microprofile/jwt/tck/parsing/TokenValidationTest.java
+++ b/tck/src/test/java/org/eclipse/microprofile/jwt/tck/parsing/TokenValidationTest.java
@@ -20,24 +20,23 @@
 package org.eclipse.microprofile.jwt.tck.parsing;
 
 import org.eclipse.microprofile.jwt.JsonWebToken;
+import org.eclipse.microprofile.jwt.tck.TCKConstants;
 import org.eclipse.microprofile.jwt.tck.util.ITokenParser;
 import org.eclipse.microprofile.jwt.tck.util.TokenUtils;
-import org.jboss.arquillian.junit.Arquillian;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
 
 import java.security.PublicKey;
 import java.util.HashSet;
 import java.util.ServiceLoader;
 import java.util.Set;
 
+import static org.eclipse.microprofile.jwt.tck.TCKConstants.TEST_GROUP_JWT;
+
 /**
  * Basic token parsing and validation tests for JWTPrincipal implementations
  */
-@RunWith(Arquillian.class)
 public class TokenValidationTest {
     private static final String TEST_ISSUER = "https://server.example.com";
     /** */
@@ -45,8 +44,9 @@ public class TokenValidationTest {
     /** */
     private static PublicKey publicKey;
 
-    @BeforeClass
-    public static void initClass() throws Exception {
+    @BeforeClass(alwaysRun=true)
+    public static void loadTokenParser() throws Exception {
+        System.out.printf("TokenValidationTest.initClass\n");
         publicKey = TokenUtils.readPublicKey("/publicKey.pem");
         if(publicKey == null) {
             throw new IllegalStateException("Failed to load /publicKey.pem resource");
@@ -61,15 +61,16 @@ public class TokenValidationTest {
         if(tokenParser == null) {
             throw new IllegalStateException(String.format("Service provider for %s  produced a null parser", ITokenParser.class.getName()));
         }
+        System.out.printf("Using ITokenParser: %s\n", tokenParser);
     }
 
     /**
      * Create a JWT token representation of the testRIJWTCallerPrincipal.json test resource and then parse it into a
      * JWTPrincipal to validate the container's implementation.
      *
-     * @throws Exception
+     * @throws Exception on parse failure
      */
-    @Test
+    @Test(groups = TEST_GROUP_JWT, description = "validate the JWTPrincipal returned by ITokenParser")
     public void testRIJWTCallerPrincipal() throws Exception {
         long nowInSeconds = System.currentTimeMillis() / 1000;
         String jwt = TokenUtils.generateTokenString("/testRIJWTCallerPrincipal.json");
@@ -78,14 +79,14 @@ public class TokenValidationTest {
         System.out.printf("Parsed caller principal: %s\n", jwtPrincipal);
 
         // Validate the required claims
-        Assert.assertEquals("bearer_token", jwt, jwtPrincipal.getRawToken());
-        Assert.assertEquals("iss", "https://server.example.com", jwtPrincipal.getIssuer());
-        Assert.assertEquals("sub", "24400320", jwtPrincipal.getSubject());
-        Assert.assertEquals("aud", "s6BhdRkqt3", jwtPrincipal.getAudience().toArray()[0]);
-        Assert.assertEquals("name", "jdoe@example.com", jwtPrincipal.getName());
-        Assert.assertEquals("jti", "a-123", jwtPrincipal.getTokenID());
-        Assert.assertTrue("exp is > nowInSeconds", jwtPrincipal.getExpirationTime() > nowInSeconds);
-        Assert.assertTrue("iat is >= nowInSeconds", jwtPrincipal.getIssuedAtTime() >= nowInSeconds);
+        Assert.assertEquals(jwt, jwtPrincipal.getRawToken(), "bearer_token");
+        Assert.assertEquals("https://server.example.com", jwtPrincipal.getIssuer(), "iss");
+        Assert.assertEquals("24400320", jwtPrincipal.getSubject(), "sub");
+        Assert.assertEquals("s6BhdRkqt3", jwtPrincipal.getAudience().toArray()[0], "aud");
+        Assert.assertEquals("jdoe@example.com", jwtPrincipal.getName(), "name");
+        Assert.assertEquals("a-123", jwtPrincipal.getTokenID(), "jti");
+        Assert.assertTrue(jwtPrincipal.getExpirationTime() > nowInSeconds, "exp is > nowInSeconds");
+        Assert.assertTrue(jwtPrincipal.getIssuedAtTime() >= nowInSeconds, "iat is >= nowInSeconds");
 
         // Validate the groups
         Set<String> groups = jwtPrincipal.getGroups();
@@ -102,11 +103,11 @@ public class TokenValidationTest {
 
         // Validate other claims
         Object authTime = jwtPrincipal.getClaim("auth_time");
-        Assert.assertTrue("auth_time is a Number", authTime instanceof Number);
-        Assert.assertTrue("auth_time as int is >= nowInSeconds", nowInSeconds <= ((Number)authTime).intValue());
+        Assert.assertTrue(authTime instanceof Number, "auth_time is a Number");
+        Assert.assertTrue(nowInSeconds <= ((Number)authTime).intValue(), "auth_time as int is >= nowInSeconds");
 
-        String preferredName = (String) jwtPrincipal.getClaim("preferred_username");
-        Assert.assertEquals("preferred_username is jdoe", "jdoe", preferredName);
+        String preferredName = jwtPrincipal.getClaim("preferred_username");
+        Assert.assertEquals("jdoe", preferredName, "preferred_username is jdoe");
     }
 
     /**
@@ -114,24 +115,23 @@ public class TokenValidationTest {
      * @throws Exception - thrown are parse failure
      * @see TokenUtils#generateTokenString(String)
      */
-    @Test
-    @Ignore("Internal test to validate the behavior of TokenUtils.generateTokenString")
+    @Test(groups = TCKConstants.TEST_GROUP_UTILS, description = "Internal test to validate the behavior of TokenUtils.generateTokenString")
     public void testUtilsToken() throws Exception {
         String jwt = TokenUtils.generateTokenString("/jwt-content1.json");
         JsonWebToken callerPrincipal = tokenParser.parse(jwt, TEST_ISSUER, publicKey);
         System.out.println(callerPrincipal);
         long nowSec = System.currentTimeMillis() / 1000;
         long iss = callerPrincipal.getIssuedAtTime();
-        Assert.assertTrue(String.format("now(%d) < 1s from iss(%d)", nowSec, iss), (nowSec - iss) < 1);
+        Assert.assertTrue((nowSec - iss) < 1, String.format("now(%d) < 1s from iss(%d)", nowSec, iss));
         long exp = callerPrincipal.getExpirationTime();
-        Assert.assertTrue(String.format("now(%d) > 299s from exp(%d)", nowSec, exp), (exp - nowSec) > 299);
+        Assert.assertTrue((exp - nowSec) > 299, String.format("now(%d) > 299s from exp(%d)", nowSec, exp));
     }
 
     /**
-     * Validate that a token that is past is exp claim should fail the parse verification
+     * Validate that a token that is past it's exp claim should fail the parse verification
      * @throws Exception - expect a Exception
      */
-    @Test()
+    @Test(groups = TEST_GROUP_JWT, description = "Validate that a token that is past exp claim should fail the parse verification")
     public void testExpiredValidation() throws Exception {
         HashSet<TokenUtils.InvalidClaims> invalidFields = new HashSet<>();
         invalidFields.add(TokenUtils.InvalidClaims.EXP);
@@ -150,7 +150,7 @@ public class TokenValidationTest {
      * Validate that if an issuer other than {@link #TEST_ISSUER} is used on the token, the token fails to validate
      * @throws Exception thrown on unexpected error
      */
-    @Test
+    @Test(groups = TEST_GROUP_JWT, description = "Validate the token fails to validate when using an invalid issuer")
     public void testBadIssuer() throws Exception {
         // Indicate that TokenUtils should overwrite the issuer with "INVALID_ISSUER"
         HashSet<TokenUtils.InvalidClaims> invalidFields = new HashSet<>();
@@ -167,7 +167,7 @@ public class TokenValidationTest {
         }
     }
 
-    @Test
+    @Test(groups = TEST_GROUP_JWT, description = "Validate the token fails to validate when using an invalid signer")
     public void testBadSigner() throws Exception {
         HashSet<TokenUtils.InvalidClaims> invalidFields = new HashSet<>();
         invalidFields.add(TokenUtils.InvalidClaims.SIGNER);

--- a/tck/src/test/java/org/eclipse/microprofile/jwt/tck/util/TokenUtilsTest.java
+++ b/tck/src/test/java/org/eclipse/microprofile/jwt/tck/util/TokenUtilsTest.java
@@ -24,9 +24,8 @@ import com.nimbusds.jose.crypto.RSASSAVerifier;
 import com.nimbusds.jwt.SignedJWT;
 import net.minidev.json.JSONObject;
 import net.minidev.json.parser.JSONParser;
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.testng.Assert;
+import org.testng.annotations.Test;
 
 import java.io.InputStream;
 import java.security.KeyPair;
@@ -36,6 +35,7 @@ import java.security.interfaces.RSAPublicKey;
 import java.util.Base64;
 
 import static net.minidev.json.parser.JSONParser.DEFAULT_PERMISSIVE_MODE;
+import static org.eclipse.microprofile.jwt.tck.TCKConstants.TEST_GROUP_UTILS;
 
 /**
  * Validation of the TokenUtils methods
@@ -45,7 +45,7 @@ public class TokenUtilsTest {
      * Verify the underlying JSONParser used by TokenUtils
      * @throws Exception
      */
-    @Test
+    @Test(groups = TEST_GROUP_UTILS)
     public void testParseRolesEndpoint() throws Exception {
         JSONParser parser = new JSONParser(DEFAULT_PERMISSIVE_MODE);
         InputStream contentIS = TokenUtils.class.getResourceAsStream("/RolesEndpoint.json");
@@ -67,7 +67,7 @@ public class TokenUtilsTest {
         // Transform the JSON content into a signed JWT
         String jwt = TokenUtils.generateTokenString("/RolesEndpoint.json");
         System.out.println(jwt);
-        /* Note that is you try to validate this token string via jwt.io debugger, you need to take the
+        /* Note that if you try to validate this token string via jwt.io debugger, you need to take the
         /publicKey.pem contents, and use
         -----BEGIN PUBLIC KEY-----
         ...
@@ -84,13 +84,12 @@ public class TokenUtilsTest {
         // Validate the string via Nimbus
         SignedJWT signedJWT = SignedJWT.parse(jwt);
         PublicKey publicKey = TokenUtils.readPublicKey("/publicKey.pem");
-        Assert.assertTrue("", publicKey instanceof RSAPublicKey);
+        Assert.assertTrue(publicKey instanceof RSAPublicKey, "publicKey isa RSAPublicKey");
         JWSVerifier verifier = new RSASSAVerifier((RSAPublicKey)publicKey);
         Assert.assertTrue(signedJWT.verify(verifier));
     }
 
-    @Ignore("Used to generate initial key testing pair")
-    @Test
+    @Test(groups = TEST_GROUP_UTILS, description = "Used to generate initial key testing pair")
     public void testKeyPairGeneration() throws Exception {
         KeyPair keyPair = TokenUtils.generateKeyPair(2048);
         PrivateKey privateKey = keyPair.getPrivate();
@@ -127,14 +126,12 @@ public class TokenUtilsTest {
         System.out.println("\n-----END RSA PUBLIC KEY-----");
     }
 
-    @Ignore("Test initial key validation")
-    @Test
+    @Test(groups = TEST_GROUP_UTILS, description = "Test initial key validation")
     public void testReadPrivateKey() throws Exception {
         PrivateKey privateKey = TokenUtils.readPrivateKey("/privateKey.pem");
         System.out.println(privateKey);
     }
-    @Ignore("Test initial key validation")
-    @Test
+    @Test(groups = TEST_GROUP_UTILS, description = "Test initial key validation")
     public void testReadPublicKey() throws Exception {
         RSAPublicKey publicKey = (RSAPublicKey) TokenUtils.readPublicKey("/publicKey.pem");
         System.out.println(publicKey);

--- a/tck/tck-base-suite.xml
+++ b/tck/tck-base-suite.xml
@@ -1,0 +1,43 @@
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+<!--
+    Licensed under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+<suite name="microprofile-jwt-auth-BaseTCK" verbose="1" preserve-order="true" configfailurepolicy="continue" >
+
+    <!-- The required base JAX-RS and CDI based tests that all MP-JWT implementations
+    must pass.
+    -->
+    <test name="base-tests">
+        <groups>
+            <run>
+                <include name="arquillian" />
+                <include name="jwt" />
+                <include name="utils" />
+                <include name="jaxrs" />
+                <include name="cdi" />
+                <exclude name="debug" />
+                <exclude name="ejb-optional" />
+                <exclude name="servlet-optional" />
+                <exclude name="jacc-optional" />
+            </run>
+        </groups>
+        <classes>
+            <class name="org.eclipse.microprofile.jwt.tck.parsing.TokenValidationTest" />
+            <class name="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" />
+            <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.PingTest" />
+            <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" />
+        </classes>
+    </test>
+
+</suite>

--- a/tck/tck-full-suite.xml
+++ b/tck/tck-full-suite.xml
@@ -1,0 +1,49 @@
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+<!--
+    Licensed under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+<suite name="microprofile-jwt-auth-FullTCK" verbose="1" preserve-order="true" configfailurepolicy="continue" >
+
+    <!-- The required base JAX-RS and CDI based tests that all MP-JWT implementations
+    must pass.
+    -->
+    <test name="base-tests">
+        <groups>
+            <run>
+                <include name="arquillian" />
+                <include name="jwt" />
+                <include name="utils" />
+                <include name="jaxrs" />
+                <include name="cdi" />
+                <exclude name="debug" />
+                <include name="ejb-optional" />
+                <include name="servlet-optional" />
+                <include name="jacc-optional" />
+            </run>
+        </groups>
+        <classes>
+            <class name="org.eclipse.microprofile.jwt.tck.parsing.TokenValidationTest" />
+            <class name="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" />
+            <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.PingTest" />
+            <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" />
+            <!-- Optional tests that validate integration with EJB, Servlet and JACC
+            container APIs.
+            -->
+            <class name="org.eclipse.microprofile.jwt.tck.container.ejb.EjbTest" />
+            <class name="org.eclipse.microprofile.jwt.tck.container.jacc.SubjectTest" />
+            <class name="org.eclipse.microprofile.jwt.tck.container.servlet.ServletTest" />
+        </classes>
+    </test>
+
+</suite>

--- a/tck/tck-null-suite.xml
+++ b/tck/tck-null-suite.xml
@@ -1,0 +1,37 @@
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+<!--
+    Licensed under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+<suite name="microprofile-jwt-auth-BaseTCK" verbose="1" preserve-order="true" configfailurepolicy="continue" >
+
+    <!-- A default test-suite.xml that includes no test classes to avoid running
+    tests during TCK artifact creation.
+    -->
+    <test name="base-tests">
+        <groups>
+            <run>
+                <include name="arquillian" />
+                <include name="jwt" />
+                <include name="utils" />
+                <include name="jaxrs" />
+                <include name="cdi" />
+                <exclude name="debug" />
+                <exclude name="ejb-optional" />
+                <exclude name="servlet-optional" />
+                <exclude name="jacc-optional" />
+            </run>
+        </groups>
+    </test>
+
+</suite>


### PR DESCRIPTION
* Switch to TestNG 
* Classify tests by groups to allow for base and optional tests
* Expand the base required tests 
* Add optional tests 
* update the spec and tck docs
* Document how to run the TCK from within an implementation's TCK harness build