### PR TITLE
Allow claim to target types (for non-portable behavior).

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/jwt/Claim.java
+++ b/api/src/main/java/org/eclipse/microprofile/jwt/Claim.java
@@ -19,6 +19,7 @@
  */
 package org.eclipse.microprofile.jwt;
 
+import javax.enterprise.util.Nonbinding;
 import javax.inject.Qualifier;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -31,13 +32,14 @@ import java.lang.annotation.Target;
  */
 @Qualifier
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER})
+@Target({ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.TYPE})
 public @interface Claim {
     /**
      * The value specifies the id name the claim to inject
      * @return the claim name
      * @see JsonWebToken#getClaim(String)
      */
+    @Nonbinding
     String value() default "";
 
     /**
@@ -45,6 +47,7 @@ public @interface Claim {
      * enum
      * @return the claim enum
      */
+    @Nonbinding
     Claims standard() default Claims.UNKNOWN;
 
 }


### PR DESCRIPTION
Make claim attributes nonbinding to allow producers.

This closes #28
This closes #32