### PR TITLE
Primitive injection of claims for @RequestScoped beans

### DIFF
--- a/tck/src/test/java/org/eclipse/microprofile/jwt/tck/container/jaxrs/PrimitiveInjectionEndpoint.java
+++ b/tck/src/test/java/org/eclipse/microprofile/jwt/tck/container/jaxrs/PrimitiveInjectionEndpoint.java
@@ -1,0 +1,319 @@
+/*
+ * Copyright (c) 2016-2017 Contributors to the Eclipse Foundation
+ *
+ *  See the NOTICE file(s) distributed with this work for additional
+ *  information regarding copyright ownership.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  You may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.eclipse.microprofile.jwt.tck.container.jaxrs;
+
+import org.eclipse.microprofile.jwt.Claim;
+import org.eclipse.microprofile.jwt.Claims;
+
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
+import javax.json.Json;
+import javax.json.JsonObject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import java.util.List;
+import java.util.Set;
+
+@Path("/endp")
+@RequestScoped
+public class PrimitiveInjectionEndpoint {
+    @Inject
+    @Claim("raw_token")
+    private String rawToken;
+    @Inject
+    @Claim("iss")
+    private String issuer;
+    @Inject
+    @Claim("upn")
+    private String upn;
+    @Inject
+    @Claim("jti")
+    private String jti;
+    @Inject
+    @Claim("aud")
+    private Set<String> aud;
+    @Inject
+    @Claim("groups")
+    private Set<String> groups;
+    @Inject
+    @Claim("iat")
+    private long issuedAt;
+    @Inject
+    @Claim("exp")
+    private long expiration;
+    @Inject
+    @Claim("sub")
+    private String subject;
+    @Inject
+    @Claim("customString")
+    private String customString;
+
+    @GET
+    @Path("/verifyInjectedIssuer")
+    @Produces(MediaType.APPLICATION_JSON)
+    public JsonObject verifyInjectedIssuer(@QueryParam("iss") String iss) {
+        boolean pass = false;
+        String msg;
+        String issValue = this.issuer;
+        if (issValue == null || issValue.length() == 0) {
+            msg = Claims.iss.name() + "value is null or empty, FAIL";
+        }
+        else if (issValue.equals(iss)) {
+            msg = Claims.iss.name() + " PASS";
+            pass = true;
+        }
+        else {
+            msg = String.format("%s: %s != %s", Claims.iss.name(), issValue, iss);
+        }
+        JsonObject result = Json.createObjectBuilder()
+                .add("pass", pass)
+                .add("msg", msg)
+                .build();
+        return result;
+    }
+
+    @GET
+    @Path("/verifyInjectedRawToken")
+    @Produces(MediaType.APPLICATION_JSON)
+    public JsonObject verifyInjectedRawToken(@QueryParam("raw_token") String rt) {
+        boolean pass = false;
+        String msg;
+        // raw_token
+        String rawTokenValue = this.rawToken;
+        if (rawTokenValue == null || rawTokenValue.length() == 0) {
+            msg = Claims.raw_token.name() + "value is null or empty, FAIL";
+        }
+        else if (rawTokenValue.equals(rt)) {
+            msg = Claims.raw_token.name() + " PASS";
+            pass = true;
+        }
+        else {
+            msg = String.format("%s: %s != %s", Claims.raw_token.name(), rawTokenValue, rt);
+        }
+        JsonObject result = Json.createObjectBuilder()
+                .add("pass", pass)
+                .add("msg", msg)
+                .build();
+        return result;
+    }
+
+    @GET
+    @Path("/verifyInjectedJTI")
+    @Produces(MediaType.APPLICATION_JSON)
+    public JsonObject verifyInjectedJTI(@QueryParam("jti") String jwtID) {
+        boolean pass = false;
+        String msg;
+        // jti
+        String jtiValue = this.jti;
+        if (jtiValue == null || jtiValue.length() == 0) {
+            msg = Claims.jti.name() + "value is null or empty, FAIL";
+        }
+        else if (jtiValue.equals(jwtID)) {
+            msg = Claims.jti.name() + " PASS";
+            pass = true;
+        }
+        else {
+            msg = String.format("%s: %s != %s", Claims.jti.name(), jtiValue, jwtID);
+        }
+        JsonObject result = Json.createObjectBuilder()
+                .add("pass", pass)
+                .add("msg", msg)
+                .build();
+        return result;
+    }
+
+    @GET
+    @Path("/verifyInjectedUPN")
+    @Produces(MediaType.APPLICATION_JSON)
+    public JsonObject verifyInjectedUPN(@QueryParam("upn") String upn) {
+        boolean pass = false;
+        String msg;
+        // uPN
+        String upnValue = this.upn;
+        if (upnValue == null || upnValue.length() == 0) {
+            msg = Claims.upn.name() + "value is null or empty, FAIL";
+        }
+        else if (upnValue.equals(upn)) {
+            msg = Claims.upn.name() + " PASS";
+            pass = true;
+        }
+        else {
+            msg = String.format("%s: %s != %s", Claims.upn.name(), upnValue, upn);
+        }
+        JsonObject result = Json.createObjectBuilder()
+                .add("pass", pass)
+                .add("msg", msg)
+                .build();
+        return result;
+    }
+
+    @GET
+    @Path("/verifyInjectedSUB")
+    @Produces(MediaType.APPLICATION_JSON)
+    public JsonObject verifyInjectedSUB(@QueryParam("sub") String sub) {
+        boolean pass = false;
+        String msg;
+        // sUB
+        String subValue = this.subject;
+        if (subValue == null || subValue.length() == 0) {
+            msg = Claims.sub.name() + "value is null or empty, FAIL";
+        }
+        else if (subValue.equals(sub)) {
+            msg = Claims.sub.name() + " PASS";
+            pass = true;
+        }
+        else {
+            msg = String.format("%s: %s != %s", Claims.sub.name(), subValue, sub);
+        }
+        JsonObject result = Json.createObjectBuilder()
+                .add("pass", pass)
+                .add("msg", msg)
+                .build();
+        return result;
+    }
+
+    @GET
+    @Path("/verifyInjectedAudience")
+    @Produces(MediaType.APPLICATION_JSON)
+    public JsonObject verifyInjectedAudience(@QueryParam("aud") String audience) {
+        boolean pass = false;
+        String msg;
+        // aud
+        Set<String> audValue = aud;
+        if (audValue == null || audValue.size() == 0) {
+            msg = Claims.aud.name() + "value is null or empty, FAIL";
+        }
+        else if (audValue.contains(audience)) {
+            msg = Claims.aud.name() + " PASS";
+            pass = true;
+        }
+        else {
+            msg = String.format("%s: %s != %s", Claims.aud.name(), audValue, audience);
+        }
+        JsonObject result = Json.createObjectBuilder()
+                .add("pass", pass)
+                .add("msg", msg)
+                .build();
+        return result;
+    }
+
+    @GET
+    @Path("/verifyInjectedGroups")
+    @Produces(MediaType.APPLICATION_JSON)
+    public JsonObject verifyInjectedGroups(@QueryParam("groups") List<String> groups) {
+        boolean pass = false;
+        String msg;
+        // groups
+        Set<String> groupsValue = this.groups;
+        if (groupsValue == null || groupsValue.size() == 0) {
+            msg = Claims.groups.name() + "value is null or empty, FAIL";
+        }
+        else if (groupsValue.containsAll(groups)) {
+            msg = Claims.groups.name() + " PASS";
+            pass = true;
+        }
+        else {
+            msg = String.format("%s: %s != %s", Claims.groups.name(), groupsValue, groups);
+        }
+        JsonObject result = Json.createObjectBuilder()
+                .add("pass", pass)
+                .add("msg", msg)
+                .build();
+        return result;
+    }
+
+    @GET
+    @Path("/verifyInjectedIssuedAt")
+    @Produces(MediaType.APPLICATION_JSON)
+    public JsonObject verifyInjectedIssuedAt(@QueryParam("iat") Long iat) {
+        boolean pass = false;
+        String msg;
+        // iat
+        Long iatValue = this.issuedAt;
+        if (iatValue == null || iatValue.intValue() == 0) {
+            msg = Claims.iat.name() + "value is null or empty, FAIL";
+        }
+        else if (iatValue.equals(iat)) {
+            msg = Claims.iat.name() + " PASS";
+            pass = true;
+        }
+        else {
+            msg = String.format("%s: %s != %s", Claims.iat.name(), iatValue, iat);
+        }
+        JsonObject result = Json.createObjectBuilder()
+                .add("pass", pass)
+                .add("msg", msg)
+                .build();
+        return result;
+    }
+
+    @GET
+    @Path("/verifyInjectedExpiration")
+    @Produces(MediaType.APPLICATION_JSON)
+    public JsonObject verifyInjectedExpiration(@QueryParam("exp") Long exp) {
+        boolean pass = false;
+        String msg;
+        // exp
+        Long expValue = this.expiration;
+        if (expValue == null || expValue.intValue() == 0) {
+            msg = Claims.exp.name() + "value is null or empty, FAIL";
+        }
+        else if (expValue.equals(exp)) {
+            msg = Claims.exp.name() + " PASS";
+            pass = true;
+        }
+        else {
+            msg = String.format("%s: %s != %s", Claims.exp.name(), expValue, exp);
+        }
+        JsonObject result = Json.createObjectBuilder()
+                .add("pass", pass)
+                .add("msg", msg)
+                .build();
+        return result;
+    }
+
+    @GET
+    @Path("/verifyInjectedCustomString")
+    @Produces(MediaType.APPLICATION_JSON)
+    public JsonObject verifyInjectedCustomString(@QueryParam("value") String value) {
+        boolean pass = false;
+        String msg;
+        // iat
+        String customValue = this.customString;
+        if (customValue == null || customValue.length() == 0) {
+            msg = "customString value is null or empty, FAIL";
+        }
+        else if (customValue.equals(value)) {
+            msg = "customString PASS";
+            pass = true;
+        }
+        else {
+            msg = String.format("customString: %s != %s", customValue, value);
+        }
+        JsonObject result = Json.createObjectBuilder()
+                .add("pass", pass)
+                .add("msg", msg)
+                .build();
+        return result;
+    }
+}

--- a/tck/src/test/java/org/eclipse/microprofile/jwt/tck/container/jaxrs/PrimitiveInjectionTest.java
+++ b/tck/src/test/java/org/eclipse/microprofile/jwt/tck/container/jaxrs/PrimitiveInjectionTest.java
@@ -1,0 +1,282 @@
+/*
+ * Copyright (c) 2016-2017 Contributors to the Eclipse Foundation
+ *
+ *  See the NOTICE file(s) distributed with this work for additional
+ *  information regarding copyright ownership.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  You may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.eclipse.microprofile.jwt.tck.container.jaxrs;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.HashMap;
+
+import javax.json.Json;
+import javax.json.JsonObject;
+import javax.json.JsonReader;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.eclipse.microprofile.jwt.Claims;
+import org.eclipse.microprofile.jwt.tck.TCKConstants;
+import org.eclipse.microprofile.jwt.tck.util.TokenUtils;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.testng.Assert;
+import org.testng.Reporter;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.eclipse.microprofile.jwt.tck.TCKConstants.TEST_GROUP_CDI_PROVIDER;
+
+/**
+ * Tests that claims can be injected as primitive types into @RequestScoped beans
+ */
+public class PrimitiveInjectionTest extends Arquillian {
+
+    /**
+     * The test generated JWT token string
+     */
+    private static String token;
+    // Time claims in the token
+    private static Long iatClaim;
+    private static Long authTimeClaim;
+    private static Long expClaim;
+
+    /**
+     * The base URL for the container under test
+     */
+    @ArquillianResource
+    private URL baseURL;
+
+    /**
+     * Create a CDI aware base web application archive
+     * @return the base base web application archive
+     * @throws IOException - on resource failure
+     */
+    @Deployment(testable=true)
+    public static WebArchive createDeployment() throws IOException {
+        URL publicKey = PrimitiveInjectionTest.class.getResource("/publicKey.pem");
+        WebArchive webArchive = ShrinkWrap
+            .create(WebArchive.class, "PrimitiveInjectionTest.war")
+            .addAsResource(publicKey, "/publicKey.pem")
+            .addClass(PrimitiveInjectionEndpoint.class)
+            .addClass(TCKApplication.class)
+            .addAsWebInfResource("beans.xml", "beans.xml")
+            ;
+        System.out.printf("WebArchive: %s\n", webArchive.toString(true));
+        return webArchive;
+    }
+
+    @BeforeClass(alwaysRun=true)
+    public static void generateToken() throws Exception {
+        HashMap<String, Long> timeClaims = new HashMap<>();
+        token = TokenUtils.generateTokenString("/Token1.json", null, timeClaims);
+        iatClaim = timeClaims.get(Claims.iat.name());
+        authTimeClaim = timeClaims.get(Claims.auth_time.name());
+        expClaim = timeClaims.get(Claims.exp.name());
+    }
+
+    @RunAsClient
+    @Test(groups = TEST_GROUP_CDI_PROVIDER,
+        description = "Verify that the injected token issuer claim is as expected")
+    public void verifyIssuerClaim() throws Exception {
+        Reporter.log("Begin verifyIssuerClaim");
+        String uri = baseURL.toExternalForm() + "/endp/verifyInjectedIssuer";
+        WebTarget echoEndpointTarget = ClientBuilder.newClient()
+            .target(uri)
+            .queryParam(Claims.iss.name(), TCKConstants.TEST_ISSUER)
+            .queryParam(Claims.auth_time.name(), authTimeClaim);
+        Response response = echoEndpointTarget.request(MediaType.APPLICATION_JSON).header(HttpHeaders.AUTHORIZATION, "Bearer " + token).get();
+        Assert.assertEquals(response.getStatus(), HttpURLConnection.HTTP_OK);
+        String replyString = response.readEntity(String.class);
+        JsonReader jsonReader = Json.createReader(new StringReader(replyString));
+        JsonObject reply = jsonReader.readObject();
+        Reporter.log(reply.toString());
+        Assert.assertTrue(reply.getBoolean("pass"), reply.getString("msg"));
+    }
+    @RunAsClient
+    @Test(groups = TEST_GROUP_CDI_PROVIDER,
+        description = "Verify that the injected raw token claim is as expected")
+    public void verifyInjectedRawToken() throws Exception {
+        Reporter.log("Begin verifyInjectedRawToken\n");
+        String uri = baseURL.toExternalForm() + "/endp/verifyInjectedRawToken";
+        WebTarget echoEndpointTarget = ClientBuilder.newClient()
+            .target(uri)
+            .queryParam(Claims.raw_token.name(), token)
+            .queryParam(Claims.auth_time.name(), authTimeClaim);
+        Response response = echoEndpointTarget.request(MediaType.APPLICATION_JSON).header(HttpHeaders.AUTHORIZATION, "Bearer " + token).get();
+        Assert.assertEquals(response.getStatus(), HttpURLConnection.HTTP_OK);
+        String replyString = response.readEntity(String.class);
+        JsonReader jsonReader = Json.createReader(new StringReader(replyString));
+        JsonObject reply = jsonReader.readObject();
+        Reporter.log(reply.toString());
+        Assert.assertTrue(reply.getBoolean("pass"), reply.getString("msg"));
+    }
+    @RunAsClient
+    @Test(groups = TEST_GROUP_CDI_PROVIDER,
+        description = "Verify that the injected jti claim is as expected")
+    public void verifyInjectedJTI() throws Exception {
+        Reporter.log("Begin verifyInjectedJTI\n");
+        String uri = baseURL.toExternalForm() + "/endp/verifyInjectedJTI";
+        WebTarget echoEndpointTarget = ClientBuilder.newClient()
+            .target(uri)
+            .queryParam(Claims.jti.name(), "a-123")
+            .queryParam(Claims.auth_time.name(), authTimeClaim);
+        Response response = echoEndpointTarget.request(MediaType.APPLICATION_JSON).header(HttpHeaders.AUTHORIZATION, "Bearer " + token).get();
+        Assert.assertEquals(response.getStatus(), HttpURLConnection.HTTP_OK);
+        String replyString = response.readEntity(String.class);
+        JsonReader jsonReader = Json.createReader(new StringReader(replyString));
+        JsonObject reply = jsonReader.readObject();
+        Reporter.log(reply.toString());
+        Assert.assertTrue(reply.getBoolean("pass"), reply.getString("msg"));
+    }
+    @RunAsClient
+    @Test(groups = TEST_GROUP_CDI_PROVIDER,
+        description = "Verify that the injected upn claim is as expected")
+    public void verifyInjectedUPN() throws Exception {
+        Reporter.log("Begin verifyInjectedUPN\n");
+        String uri = baseURL.toExternalForm() + "/endp/verifyInjectedUPN";
+        WebTarget echoEndpointTarget = ClientBuilder.newClient()
+            .target(uri)
+            .queryParam(Claims.upn.name(), "jdoe@example.com")
+            .queryParam(Claims.auth_time.name(), authTimeClaim);
+        Response response = echoEndpointTarget.request(MediaType.APPLICATION_JSON).header(HttpHeaders.AUTHORIZATION, "Bearer " + token).get();
+        Assert.assertEquals(response.getStatus(), HttpURLConnection.HTTP_OK);
+        String replyString = response.readEntity(String.class);
+        JsonReader jsonReader = Json.createReader(new StringReader(replyString));
+        JsonObject reply = jsonReader.readObject();
+        Reporter.log(reply.toString());
+        Assert.assertTrue(reply.getBoolean("pass"), reply.getString("msg"));
+    }
+    @RunAsClient
+    @Test(groups = TEST_GROUP_CDI_PROVIDER,
+        description = "Verify that the injected sub claim is as expected")
+    public void verifyInjectedSUB() throws Exception {
+        Reporter.log("Begin verifyInjectedSUB\n");
+        String uri = baseURL.toExternalForm() + "/endp/verifyInjectedSUB";
+        WebTarget echoEndpointTarget = ClientBuilder.newClient()
+            .target(uri)
+            .queryParam(Claims.sub.name(), "24400320")
+            .queryParam(Claims.auth_time.name(), authTimeClaim);
+        Response response = echoEndpointTarget.request(MediaType.APPLICATION_JSON).header(HttpHeaders.AUTHORIZATION, "Bearer " + token).get();
+        Assert.assertEquals(response.getStatus(), HttpURLConnection.HTTP_OK);
+        String replyString = response.readEntity(String.class);
+        JsonReader jsonReader = Json.createReader(new StringReader(replyString));
+        JsonObject reply = jsonReader.readObject();
+        Reporter.log(reply.toString());
+        Assert.assertTrue(reply.getBoolean("pass"), reply.getString("msg"));
+    }
+    @RunAsClient
+    @Test(groups = TEST_GROUP_CDI_PROVIDER,
+        description = "Verify that the injected aud claim is as expected")
+    public void verifyInjectedAudience() throws Exception {
+        Reporter.log("Begin verifyInjectedAudience\n");
+        String uri = baseURL.toExternalForm() + "/endp/verifyInjectedAudience";
+        WebTarget echoEndpointTarget = ClientBuilder.newClient()
+            .target(uri)
+            .queryParam(Claims.aud.name(), new String[]{"s6BhdRkqt3"})
+            .queryParam(Claims.auth_time.name(), authTimeClaim);
+        Response response = echoEndpointTarget.request(MediaType.APPLICATION_JSON).header(HttpHeaders.AUTHORIZATION, "Bearer " + token).get();
+        Assert.assertEquals(response.getStatus(), HttpURLConnection.HTTP_OK);
+        String replyString = response.readEntity(String.class);
+        JsonReader jsonReader = Json.createReader(new StringReader(replyString));
+        JsonObject reply = jsonReader.readObject();
+        Reporter.log(reply.toString());
+        Assert.assertTrue(reply.getBoolean("pass"), reply.getString("msg"));
+    }
+    @RunAsClient
+    @Test(groups = TEST_GROUP_CDI_PROVIDER,
+        description = "Verify that the injected groups claim is as expected")
+    public void verifyInjectedGroups() throws Exception {
+        Reporter.log("Begin verifyInjectedGroups\n");
+        String uri = baseURL.toExternalForm() + "/endp/verifyInjectedGroups";
+        WebTarget echoEndpointTarget = ClientBuilder.newClient()
+            .target(uri)
+            .queryParam(Claims.groups.name(), new String[]{
+                    "Echoer", "Tester", "group1", "group2"})
+                .queryParam(Claims.auth_time.name(), authTimeClaim);
+        Response response = echoEndpointTarget.request(MediaType.APPLICATION_JSON).header(HttpHeaders.AUTHORIZATION, "Bearer " + token).get();
+        Assert.assertEquals(response.getStatus(), HttpURLConnection.HTTP_OK);
+        String replyString = response.readEntity(String.class);
+        JsonReader jsonReader = Json.createReader(new StringReader(replyString));
+        JsonObject reply = jsonReader.readObject();
+        Reporter.log(reply.toString());
+        Assert.assertTrue(reply.getBoolean("pass"), reply.getString("msg"));
+    }
+    @RunAsClient
+    @Test(groups = TEST_GROUP_CDI_PROVIDER,
+        description = "Verify that the injected iat claim is as expected")
+    public void verifyInjectedIssuedAt() throws Exception {
+        Reporter.log("Begin verifyInjectedIssuedAt\n");
+        String uri = baseURL.toExternalForm() + "/endp/verifyInjectedIssuedAt";
+        WebTarget echoEndpointTarget = ClientBuilder.newClient()
+            .target(uri)
+            .queryParam(Claims.iat.name(), iatClaim)
+            .queryParam(Claims.auth_time.name(), authTimeClaim);
+        Response response = echoEndpointTarget.request(MediaType.APPLICATION_JSON).header(HttpHeaders.AUTHORIZATION, "Bearer " + token).get();
+        Assert.assertEquals(response.getStatus(), HttpURLConnection.HTTP_OK);
+        String replyString = response.readEntity(String.class);
+        JsonReader jsonReader = Json.createReader(new StringReader(replyString));
+        JsonObject reply = jsonReader.readObject();
+        Reporter.log(reply.toString());
+        Assert.assertTrue(reply.getBoolean("pass"), reply.getString("msg"));
+    }
+    @RunAsClient
+    @Test(groups = TEST_GROUP_CDI_PROVIDER,
+        description = "Verify that the injected exp claim is as expected")
+    public void verifyInjectedExpiration() throws Exception {
+        Reporter.log("Begin verifyInjectedExpiration\n");
+        String uri = baseURL.toExternalForm() + "/endp/verifyInjectedExpiration";
+        WebTarget echoEndpointTarget = ClientBuilder.newClient()
+            .target(uri)
+            .queryParam(Claims.exp.name(), expClaim)
+            .queryParam(Claims.auth_time.name(), authTimeClaim);
+        Response response = echoEndpointTarget.request(MediaType.APPLICATION_JSON).header(HttpHeaders.AUTHORIZATION, "Bearer " + token).get();
+        Assert.assertEquals(response.getStatus(), HttpURLConnection.HTTP_OK);
+        String replyString = response.readEntity(String.class);
+        JsonReader jsonReader = Json.createReader(new StringReader(replyString));
+        JsonObject reply = jsonReader.readObject();
+        Reporter.log(reply.toString());
+        Assert.assertTrue(reply.getBoolean("pass"), reply.getString("msg"));
+    }
+    @RunAsClient
+    @Test(groups = TEST_GROUP_CDI_PROVIDER,
+        description = "Verify that the injected customString claim is as expected")
+    public void verifyInjectedCustomString() throws Exception {
+        Reporter.log("Begin verifyInjectedCustomString\n");
+        String uri = baseURL.toExternalForm() + "/endp/verifyInjectedCustomString";
+        WebTarget echoEndpointTarget = ClientBuilder.newClient()
+            .target(uri)
+            .queryParam("value", "customStringValue")
+            .queryParam(Claims.auth_time.name(), authTimeClaim);
+        Response response = echoEndpointTarget.request(MediaType.APPLICATION_JSON).header(HttpHeaders.AUTHORIZATION, "Bearer " + token).get();
+        Assert.assertEquals(response.getStatus(), HttpURLConnection.HTTP_OK);
+        String replyString = response.readEntity(String.class);
+        JsonReader jsonReader = Json.createReader(new StringReader(replyString));
+        JsonObject reply = jsonReader.readObject();
+        Reporter.log(reply.toString());
+        Assert.assertTrue(reply.getBoolean("pass"), reply.getString("msg"));
+    }
+}


### PR DESCRIPTION
Tests to assert support detailed in specification for injecting claims as their primitive types into `@RequestScoped` beans

From Section 7.1.2

```
@Path("/endp")
@RequestScoped
public class RolesEndpoint {
...
// Raw types
@Inject
@Claim(standard = Claims.raw_token)
private String rawToken;
@Inject ①
@Claim(standard=Claims.iat)
private Long issuedAt;

```