### PR TITLE
Correct the hard-coded URL in validateLocationUrlContents

### DIFF
--- a/tck/src/test/java/org/eclipse/microprofile/jwt/tck/config/PublicKeyAsPEMLocationURLTest.java
+++ b/tck/src/test/java/org/eclipse/microprofile/jwt/tck/config/PublicKeyAsPEMLocationURLTest.java
@@ -111,7 +111,7 @@ public class PublicKeyAsPEMLocationURLTest extends Arquillian {
     @Test(groups = TEST_GROUP_CONFIG,
         description = "Validate the http://localhost:8080/pem/endp/publicKey4k PEM endpoint")
     public void validateLocationUrlContents() throws Exception {
-        URL locationURL = new URL("http://localhost:8080/pem/endp/publicKey4k");
+        URL locationURL = new URL(baseURL, "pem/endp/publicKey4k");
         Reporter.log("Begin validateLocationUrlContents");
 
         StringWriter content = new StringWriter();


### PR DESCRIPTION
#104 publicKeyAsPEMLocationURLTest#114 still has hardcoded URL.