### PR TITLE
Revert "Add methods to JsonWebToken to get claims by using the Claims enum"

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/jwt/JsonWebToken.java
+++ b/api/src/main/java/org/eclipse/microprofile/jwt/JsonWebToken.java
@@ -48,7 +48,7 @@ public interface JsonWebToken extends Principal {
      * @return raw bear token string
      */
     default String getRawToken() {
-        return getClaim(Claims.raw_token);
+        return getClaim(Claims.raw_token.name());
     }
 
     /**
@@ -56,7 +56,7 @@ public interface JsonWebToken extends Principal {
      * @return the iss claim.
      */
     default String getIssuer() {
-        return getClaim(Claims.iss);
+        return getClaim(Claims.iss.name());
     }
 
     /**
@@ -65,7 +65,7 @@ public interface JsonWebToken extends Principal {
      * @return the aud claim or null if the claim is not present
      */
     default Set<String> getAudience() {
-        return getClaim(Claims.aud);
+        return getClaim(Claims.aud.name());
     }
 
     /**
@@ -76,7 +76,7 @@ public interface JsonWebToken extends Principal {
      * @return the sub claim.
      */
     default String getSubject() {
-        return getClaim(Claims.sub);
+        return getClaim(Claims.sub.name());
     }
 
     /**
@@ -90,7 +90,7 @@ public interface JsonWebToken extends Principal {
      * @return the jti claim.
      */
     default String getTokenID() {
-        return getClaim(Claims.jti);
+        return getClaim(Claims.jti.name());
     }
 
     /**
@@ -100,7 +100,7 @@ public interface JsonWebToken extends Principal {
      * @return the exp claim.
      */
     default long getExpirationTime() {
-        return getClaim(Claims.exp);
+        return getClaim(Claims.exp.name());
     }
 
     /**
@@ -109,7 +109,7 @@ public interface JsonWebToken extends Principal {
      * @return the iat claim
      */
     default long getIssuedAtTime() {
-        return getClaim(Claims.iat);
+        return getClaim(Claims.iat.name());
     }
 
     /**
@@ -120,7 +120,7 @@ public interface JsonWebToken extends Principal {
      * @return a possibly empty set of group names.
      */
     default Set<String> getGroups() {
-        return getClaim(Claims.groups);
+        return getClaim(Claims.groups.name());
     }
 
     /**
@@ -140,23 +140,12 @@ public interface JsonWebToken extends Principal {
 
     /**
      * Access the value of the indicated claim.
-     *
+     * 
      * @param <T> The claim type
      * @param claimName - the name of the claim
      * @return the value of the indicated claim if it exists, null otherwise.
      */
     <T> T getClaim(String claimName);
-
-    /**
-     * Access the value of the indicated claim.
-     *
-     * @param <T> The claim type
-     * @param claim - the claim
-     * @return the value of the indicated claim if it exists, null otherwise.
-     */
-    default <T> T getClaim(Claims claim) {
-        return getClaim(claim.name());
-    }
 
     /**
      * A utility method to access a claim value in an {@linkplain Optional}
@@ -167,16 +156,5 @@ public interface JsonWebToken extends Principal {
      */
     default <T> Optional<T> claim(String claimName) {
         return Optional.ofNullable(getClaim(claimName));
-    }
-
-    /**
-     * A utility method to access a claim value in an {@linkplain Optional}
-     * wrapper
-     * @param claim - the claim
-     * @param <T> - the type of the claim value to return
-     * @return an Optional wrapper of the claim value
-     */
-    default <T> Optional<T> claim(Claims claim) {
-        return claim(claim.name());
     }
 }


### PR DESCRIPTION
Reverts eclipse/microprofile-jwt-auth#155 due to this build failure:

https://ci.eclipse.org/microprofile/job/JWT-Auth-maven-snapshots/1063/

```
[ERROR] Failed to execute goal biz.aQute.bnd:bnd-baseline-maven-plugin:3.5.0:baseline (baseline) on project microprofile-jwt-auth-api: An error occurred while calculating the baseline: The baselining plugin detected versioning errors -> [Help 1]
```