### PR TITLE
Add get claims with claims, update bnd plugin version and increase jwt package osgi version to 1.1

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -28,6 +28,10 @@
     <name>MicroProfile JWT Auth API</name>
     <description>Eclipse MicroProfile JWT Feature - API</description>
 
+    <properties>
+        <bnd.version>5.0.0</bnd.version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>jakarta.json</groupId>
@@ -75,7 +79,7 @@
             <plugin>
                 <groupId>biz.aQute.bnd</groupId>
                 <artifactId>bnd-maven-plugin</artifactId>
-                <version>3.4.0</version>
+                <version>${bnd.version}</version>
 
                 <executions>
                     <execution>
@@ -99,8 +103,10 @@
             <plugin>
                 <groupId>biz.aQute.bnd</groupId>
                 <artifactId>bnd-baseline-maven-plugin</artifactId>
-                <version>3.5.0</version>
-                
+                <version>${bnd.version}</version>
+                <configuration>
+                    <fullReport>true</fullReport>
+                </configuration>
                 <executions>
                     <execution>
                         <id>baseline</id>

--- a/api/src/main/java/org/eclipse/microprofile/jwt/JsonWebToken.java
+++ b/api/src/main/java/org/eclipse/microprofile/jwt/JsonWebToken.java
@@ -48,7 +48,7 @@ public interface JsonWebToken extends Principal {
      * @return raw bear token string
      */
     default String getRawToken() {
-        return getClaim(Claims.raw_token.name());
+        return getClaim(Claims.raw_token);
     }
 
     /**
@@ -56,7 +56,7 @@ public interface JsonWebToken extends Principal {
      * @return the iss claim.
      */
     default String getIssuer() {
-        return getClaim(Claims.iss.name());
+        return getClaim(Claims.iss);
     }
 
     /**
@@ -65,7 +65,7 @@ public interface JsonWebToken extends Principal {
      * @return the aud claim or null if the claim is not present
      */
     default Set<String> getAudience() {
-        return getClaim(Claims.aud.name());
+        return getClaim(Claims.aud);
     }
 
     /**
@@ -76,7 +76,7 @@ public interface JsonWebToken extends Principal {
      * @return the sub claim.
      */
     default String getSubject() {
-        return getClaim(Claims.sub.name());
+        return getClaim(Claims.sub);
     }
 
     /**
@@ -90,7 +90,7 @@ public interface JsonWebToken extends Principal {
      * @return the jti claim.
      */
     default String getTokenID() {
-        return getClaim(Claims.jti.name());
+        return getClaim(Claims.jti);
     }
 
     /**
@@ -100,7 +100,7 @@ public interface JsonWebToken extends Principal {
      * @return the exp claim.
      */
     default long getExpirationTime() {
-        return getClaim(Claims.exp.name());
+        return getClaim(Claims.exp);
     }
 
     /**
@@ -109,7 +109,7 @@ public interface JsonWebToken extends Principal {
      * @return the iat claim
      */
     default long getIssuedAtTime() {
-        return getClaim(Claims.iat.name());
+        return getClaim(Claims.iat);
     }
 
     /**
@@ -120,7 +120,7 @@ public interface JsonWebToken extends Principal {
      * @return a possibly empty set of group names.
      */
     default Set<String> getGroups() {
-        return getClaim(Claims.groups.name());
+        return getClaim(Claims.groups);
     }
 
     /**
@@ -140,12 +140,23 @@ public interface JsonWebToken extends Principal {
 
     /**
      * Access the value of the indicated claim.
-     * 
+     *
      * @param <T> The claim type
      * @param claimName - the name of the claim
      * @return the value of the indicated claim if it exists, null otherwise.
      */
     <T> T getClaim(String claimName);
+
+    /**
+     * Access the value of the indicated claim.
+     *
+     * @param <T> The claim type
+     * @param claim - the claim
+     * @return the value of the indicated claim if it exists, null otherwise.
+     */
+    default <T> T getClaim(Claims claim) {
+        return getClaim(claim.name());
+    }
 
     /**
      * A utility method to access a claim value in an {@linkplain Optional}
@@ -156,5 +167,16 @@ public interface JsonWebToken extends Principal {
      */
     default <T> Optional<T> claim(String claimName) {
         return Optional.ofNullable(getClaim(claimName));
+    }
+
+    /**
+     * A utility method to access a claim value in an {@linkplain Optional}
+     * wrapper
+     * @param claim - the claim
+     * @param <T> - the type of the claim value to return
+     * @return an Optional wrapper of the claim value
+     */
+    default <T> Optional<T> claim(Claims claim) {
+        return claim(claim.name());
     }
 }

--- a/api/src/main/java/org/eclipse/microprofile/jwt/package-info.java
+++ b/api/src/main/java/org/eclipse/microprofile/jwt/package-info.java
@@ -37,5 +37,5 @@
  *
  *
  */
-@org.osgi.annotation.versioning.Version("1.0")
+@org.osgi.annotation.versioning.Version("1.1")
 package org.eclipse.microprofile.jwt;


### PR DESCRIPTION
As discussed in #154 as well as #155 and #156.

This PR adds a default method to retrieve claims with the `Claims` enum. Furthermore, following the discussions mentioned above, the bnd plugin version is increased and the osgi package version of the jwt package is increased to 1.1.

fixes #154 