### PR TITLE
Fix All JAXRS TCK tests and update the licence year for the affected tests

### DIFF
--- a/tck/README.adoc
+++ b/tck/README.adoc
@@ -49,6 +49,8 @@ invalid tokens. A summary of the tck/resources directory contents is:
 
 * META-INF/microprofile-config-publickey.properties
 ** A base MicroProfile config properties file for the org.eclipse.microprofile.jwt.tck.config.* package tests.
+* META-INF/microprofile-config-publickey-location.properties
+** A base MicroProfile config properties file for the org.eclipse.microprofile.jwt.tck.jaxrs.* package tests.
 * jwt-content1.json
 * testJWTCallerPrincipal.json
 * usePreferredName.json

--- a/tck/src/test/java/org/eclipse/microprofile/jwt/tck/config/PublicKeyAsPEMTest.java
+++ b/tck/src/test/java/org/eclipse/microprofile/jwt/tck/config/PublicKeyAsPEMTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016-2020 Contributors to the Eclipse Foundation
  *
  *  See the NOTICE file(s) distributed with this work for additional
  *  information regarding copyright ownership.

--- a/tck/src/test/java/org/eclipse/microprofile/jwt/tck/container/jaxrs/ClaimValueInjectionTest.java
+++ b/tck/src/test/java/org/eclipse/microprofile/jwt/tck/container/jaxrs/ClaimValueInjectionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016-2020 Contributors to the Eclipse Foundation
  *
  *  See the NOTICE file(s) distributed with this work for additional
  *  information regarding copyright ownership.
@@ -63,7 +63,6 @@ public class ClaimValueInjectionTest extends Arquillian {
     // Time claims in the token
     private static Long iatClaim;
     private static Long authTimeClaim;
-    private static Long expClaim;
 
     /**
      * The base URL for the container under test
@@ -78,6 +77,7 @@ public class ClaimValueInjectionTest extends Arquillian {
      */
     @Deployment(testable=true)
     public static WebArchive createDeployment() throws IOException {
+        URL config = ClaimValueInjectionTest.class.getResource("/META-INF/microprofile-config-publickey-location.properties");
         URL publicKey = ClaimValueInjectionTest.class.getResource("/publicKey.pem");
         WebArchive webArchive = ShrinkWrap
             .create(WebArchive.class, "ClaimValueInjectionTest.war")
@@ -86,7 +86,7 @@ public class ClaimValueInjectionTest extends Arquillian {
             .addClass(ClaimValueInjectionEndpoint.class)
             .addClass(TCKApplication.class)
             .addAsWebInfResource("beans.xml", "beans.xml")
-            ;
+            .addAsManifestResource(config, "microprofile-config.properties");
         System.out.printf("WebArchive: %s\n", webArchive.toString(true));
         return webArchive;
     }
@@ -97,7 +97,6 @@ public class ClaimValueInjectionTest extends Arquillian {
         token = TokenUtils.generateTokenString("/Token1.json", null, timeClaims);
         iatClaim = timeClaims.get(Claims.iat.name());
         authTimeClaim = timeClaims.get(Claims.auth_time.name());
-        expClaim = timeClaims.get(Claims.exp.name());
     }
 
     @RunAsClient

--- a/tck/src/test/java/org/eclipse/microprofile/jwt/tck/container/jaxrs/InvalidTokenTest.java
+++ b/tck/src/test/java/org/eclipse/microprofile/jwt/tck/container/jaxrs/InvalidTokenTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016-2020 Contributors to the Eclipse Foundation
  *
  *  See the NOTICE file(s) distributed with this work for additional
  *  information regarding copyright ownership.
@@ -60,6 +60,7 @@ public class InvalidTokenTest extends Arquillian {
      */
     @Deployment(testable=true)
     public static WebArchive createDeployment() throws IOException {
+        URL config = InvalidTokenTest.class.getResource("/META-INF/microprofile-config-publickey-location.properties");
         URL publicKey = InvalidTokenTest.class.getResource("/publicKey.pem");
         WebArchive webArchive = ShrinkWrap
             .create(WebArchive.class, "InvalidTokenTest.war")
@@ -68,7 +69,7 @@ public class InvalidTokenTest extends Arquillian {
             .addClass(RolesEndpoint.class)
             .addClass(TCKApplication.class)
             .addAsWebInfResource("beans.xml", "beans.xml")
-            ;
+            .addAsManifestResource(config, "microprofile-config.properties");
         System.out.printf("WebArchive: %s\n", webArchive.toString(true));
         return webArchive;
     }

--- a/tck/src/test/java/org/eclipse/microprofile/jwt/tck/container/jaxrs/JsonValueInjectionTest.java
+++ b/tck/src/test/java/org/eclipse/microprofile/jwt/tck/container/jaxrs/JsonValueInjectionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016-2020 Contributors to the Eclipse Foundation
  *
  *  See the NOTICE file(s) distributed with this work for additional
  *  information regarding copyright ownership.
@@ -64,7 +64,6 @@ public class JsonValueInjectionTest extends Arquillian {
     // Time claims in the token
     private static Long iatClaim;
     private static Long authTimeClaim;
-    private static Long expClaim;
 
     /**
      * The base URL for the container under test
@@ -79,6 +78,7 @@ public class JsonValueInjectionTest extends Arquillian {
      */
     @Deployment(testable=true)
     public static WebArchive createDeployment() throws IOException {
+        URL config = JsonValueInjectionTest.class.getResource("/META-INF/microprofile-config-publickey-location.properties");
         URL publicKey = JsonValueInjectionTest.class.getResource("/publicKey.pem");
         WebArchive webArchive = ShrinkWrap
                 .create(WebArchive.class, "JsonValueInjectionTest.war")
@@ -86,7 +86,8 @@ public class JsonValueInjectionTest extends Arquillian {
                 .addAsResource(publicKey, "/publicKey.pem")
                 .addClass(JsonValuejectionEndpoint.class)
                 .addClass(TCKApplication.class)
-                .addAsWebInfResource("beans.xml", "beans.xml");
+                .addAsWebInfResource("beans.xml", "beans.xml")
+                .addAsManifestResource(config, "microprofile-config.properties");
         System.out.printf("WebArchive: %s\n", webArchive.toString(true));
         return webArchive;
     }
@@ -98,7 +99,6 @@ public class JsonValueInjectionTest extends Arquillian {
         token = TokenUtils.generateTokenString("/Token1.json", null, timeClaims);
         iatClaim = timeClaims.get(Claims.iat.name());
         authTimeClaim = timeClaims.get(Claims.auth_time.name());
-        expClaim = timeClaims.get(Claims.exp.name());
     }
 
     @RunAsClient

--- a/tck/src/test/java/org/eclipse/microprofile/jwt/tck/container/jaxrs/PrimitiveInjectionTest.java
+++ b/tck/src/test/java/org/eclipse/microprofile/jwt/tck/container/jaxrs/PrimitiveInjectionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016-2020 Contributors to the Eclipse Foundation
  *
  *  See the NOTICE file(s) distributed with this work for additional
  *  information regarding copyright ownership.
@@ -51,7 +51,6 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static org.eclipse.microprofile.jwt.tck.TCKConstants.TEST_GROUP_CDI_PROVIDER;
-
 /**
  * Tests that claims can be injected as primitive types into @RequestScoped beans
  */
@@ -79,6 +78,7 @@ public class PrimitiveInjectionTest extends Arquillian {
      */
     @Deployment(testable=true)
     public static WebArchive createDeployment() throws IOException {
+        URL config = PrimitiveInjectionTest.class.getResource("/META-INF/microprofile-config-publickey-location.properties");
         URL publicKey = PrimitiveInjectionTest.class.getResource("/publicKey.pem");
         WebArchive webArchive = ShrinkWrap
             .create(WebArchive.class, "PrimitiveInjectionTest.war")
@@ -87,7 +87,7 @@ public class PrimitiveInjectionTest extends Arquillian {
             .addClass(PrimitiveInjectionEndpoint.class)
             .addClass(TCKApplication.class)
             .addAsWebInfResource("beans.xml", "beans.xml")
-            ;
+            .addAsManifestResource(config, "microprofile-config.properties");
         System.out.printf("WebArchive: %s\n", webArchive.toString(true));
         return webArchive;
     }

--- a/tck/src/test/java/org/eclipse/microprofile/jwt/tck/container/jaxrs/PrincipalInjectionTest.java
+++ b/tck/src/test/java/org/eclipse/microprofile/jwt/tck/container/jaxrs/PrincipalInjectionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016-2020 Contributors to the Eclipse Foundation
  *
  *  See the NOTICE file(s) distributed with this work for additional
  *  information regarding copyright ownership.
@@ -23,7 +23,6 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
-import java.util.HashMap;
 
 import javax.json.Json;
 import javax.json.JsonObject;
@@ -34,7 +33,6 @@ import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
-import org.eclipse.microprofile.jwt.Claims;
 import org.eclipse.microprofile.jwt.tck.util.MpJwtTestVersion;
 import org.eclipse.microprofile.jwt.tck.util.TokenUtils;
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -61,9 +59,7 @@ public class PrincipalInjectionTest extends Arquillian {
      * The test generated JWT token string
      */
     private static String token;
-    // Time claims in the token
-    private static Long authTimeClaim;
-
+    
     /**
      * The base URL for the container under test
      */
@@ -77,6 +73,7 @@ public class PrincipalInjectionTest extends Arquillian {
      */
     @Deployment(testable=true)
     public static WebArchive createDeployment() throws IOException {
+        URL config = PrincipalInjectionTest.class.getResource("/META-INF/microprofile-config-publickey-location.properties");
         URL publicKey = PrincipalInjectionTest.class.getResource("/publicKey.pem");
         WebArchive webArchive = ShrinkWrap
                 .create(WebArchive.class, "PrincipalInjectionTest.war")
@@ -84,16 +81,15 @@ public class PrincipalInjectionTest extends Arquillian {
                 .addAsResource(publicKey, "/publicKey.pem")
                 .addClass(PrincipalInjectionEndpoint.class)
                 .addClass(TCKApplication.class)
-                .addAsWebInfResource("beans.xml", "beans.xml");
+                .addAsWebInfResource("beans.xml", "beans.xml")
+                .addAsManifestResource(config, "microprofile-config.properties");
         System.out.printf("WebArchive: %s\n", webArchive.toString(true));
         return webArchive;
     }
 
     @BeforeClass(alwaysRun=true)
     public static void generateToken() throws Exception {
-        HashMap<String, Long> timeClaims = new HashMap<>();
-        token = TokenUtils.generateTokenString("/Token1.json", null, timeClaims);
-        authTimeClaim = timeClaims.get(Claims.auth_time.name());
+        token = TokenUtils.generateTokenString("/Token1.json");
     }
 
     @RunAsClient

--- a/tck/src/test/java/org/eclipse/microprofile/jwt/tck/container/jaxrs/ProviderInjectionTest.java
+++ b/tck/src/test/java/org/eclipse/microprofile/jwt/tck/container/jaxrs/ProviderInjectionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016-2020 Contributors to the Eclipse Foundation
  *
  *  See the NOTICE file(s) distributed with this work for additional
  *  information regarding copyright ownership.
@@ -64,7 +64,6 @@ public class ProviderInjectionTest extends Arquillian {
     // Time claims in the token
     private static Long iatClaim;
     private static Long authTimeClaim;
-    private static Long expClaim;
 
     /**
      * The base URL for the container under test
@@ -79,6 +78,7 @@ public class ProviderInjectionTest extends Arquillian {
      */
     @Deployment(testable=true)
     public static WebArchive createDeployment() throws IOException {
+        URL config = ProviderInjectionTest.class.getResource("/META-INF/microprofile-config-publickey-location.properties");
         URL publicKey = ProviderInjectionTest.class.getResource("/publicKey.pem");
         WebArchive webArchive = ShrinkWrap
             .create(WebArchive.class, "ProviderInjectionTest.war")
@@ -87,7 +87,7 @@ public class ProviderInjectionTest extends Arquillian {
             .addClass(ProviderInjectionEndpoint.class)
             .addClass(TCKApplication.class)
             .addAsWebInfResource("beans.xml", "beans.xml")
-            ;
+            .addAsManifestResource(config, "microprofile-config.properties");
         System.out.printf("WebArchive: %s\n", webArchive.toString(true));
         return webArchive;
     }
@@ -98,7 +98,6 @@ public class ProviderInjectionTest extends Arquillian {
         token = TokenUtils.generateTokenString("/Token1.json", null, timeClaims);
         iatClaim = timeClaims.get(Claims.iat.name());
         authTimeClaim = timeClaims.get(Claims.auth_time.name());
-        expClaim = timeClaims.get(Claims.exp.name());
     }
 
     @RunAsClient

--- a/tck/src/test/java/org/eclipse/microprofile/jwt/tck/container/jaxrs/RequiredClaimsTest.java
+++ b/tck/src/test/java/org/eclipse/microprofile/jwt/tck/container/jaxrs/RequiredClaimsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016-2020 Contributors to the Eclipse Foundation
  *
  *  See the NOTICE file(s) distributed with this work for additional
  *  information regarding copyright ownership.
@@ -80,6 +80,7 @@ public class RequiredClaimsTest extends Arquillian {
      */
     @Deployment(testable = true)
     public static WebArchive createDeployment() throws IOException {
+        URL config = RequiredClaimsTest.class.getResource("/META-INF/microprofile-config-publickey-location.properties");
         URL publicKey = RequiredClaimsTest.class.getResource("/publicKey.pem");
         WebArchive webArchive = ShrinkWrap
                 .create(WebArchive.class, "RequiredClaimsTest.war")
@@ -87,7 +88,8 @@ public class RequiredClaimsTest extends Arquillian {
                 .addAsResource(publicKey, "/publicKey.pem")
                 .addClass(RequiredClaimsEndpoint.class)
                 .addClass(TCKApplication.class)
-                .addAsWebInfResource("beans.xml", "beans.xml");
+                .addAsWebInfResource("beans.xml", "beans.xml")
+                .addAsManifestResource(config, "microprofile-config.properties");
         System.out.printf("WebArchive: %s\n", webArchive.toString(true));
         return webArchive;
     }

--- a/tck/src/test/java/org/eclipse/microprofile/jwt/tck/container/jaxrs/RolesAllowedTest.java
+++ b/tck/src/test/java/org/eclipse/microprofile/jwt/tck/container/jaxrs/RolesAllowedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016-2020 Contributors to the Eclipse Foundation
  *
  *  See the NOTICE file(s) distributed with this work for additional
  *  information regarding copyright ownership.
@@ -19,7 +19,6 @@
  */
 package org.eclipse.microprofile.jwt.tck.container.jaxrs;
 
-import org.eclipse.microprofile.jwt.Claims;
 import org.eclipse.microprofile.jwt.tck.TCKConstants;
 import org.eclipse.microprofile.jwt.tck.util.MpJwtTestVersion;
 import org.eclipse.microprofile.jwt.tck.util.TokenUtils;
@@ -44,7 +43,6 @@ import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.Base64;
-import java.util.HashMap;
 
 import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
 import static org.eclipse.microprofile.jwt.tck.TCKConstants.TEST_GROUP_CDI;
@@ -60,10 +58,6 @@ public class RolesAllowedTest extends Arquillian {
      * The test generated JWT token string
      */
     private static String token;
-    // Time claims in the token
-    private static Long iatClaim;
-    private static Long authTimeClaim;
-    private static Long expClaim;
 
     /**
      * The base URL for the container under test
@@ -78,6 +72,7 @@ public class RolesAllowedTest extends Arquillian {
      */
     @Deployment(testable=true)
     public static WebArchive createDeployment() throws IOException {
+        URL config = RolesAllowedTest.class.getResource("/META-INF/microprofile-config-publickey-location.properties");
         URL publicKey = RolesAllowedTest.class.getResource("/publicKey.pem");
         WebArchive webArchive = ShrinkWrap
             .create(WebArchive.class, "RolesAllowedTest.war")
@@ -86,18 +81,14 @@ public class RolesAllowedTest extends Arquillian {
             .addClass(RolesEndpoint.class)
             .addClass(TCKApplication.class)
             .addAsWebInfResource("beans.xml", "beans.xml")
-            ;
+            .addAsManifestResource(config, "microprofile-config.properties");
         System.out.printf("WebArchive: %s\n", webArchive.toString(true));
         return webArchive;
     }
 
     @BeforeClass(alwaysRun=true)
     public static void generateToken() throws Exception {
-        HashMap<String, Long> timeClaims = new HashMap<>();
-        token = TokenUtils.generateTokenString("/Token1.json", null, timeClaims);
-        iatClaim = timeClaims.get(Claims.iat.name());
-        authTimeClaim = timeClaims.get(Claims.auth_time.name());
-        expClaim = timeClaims.get(Claims.exp.name());
+        token = TokenUtils.generateTokenString("/Token1.json", null);
     }
 
     @RunAsClient

--- a/tck/src/test/resources/META-INF/microprofile-config-publickey-location.properties
+++ b/tck/src/test/resources/META-INF/microprofile-config-publickey-location.properties
@@ -18,5 +18,5 @@
 #
 
 # A reference to the publicKey4k.pem contents embedded location
-mp.jwt.verify.publickey.location=/publicKey4k.pem
-mp.jwt.verify.publickey.issuer=https://server.example.com
+mp.jwt.verify.publickey.location=/publicKey.pem
+mp.jwt.verify.issuer=https://server.example.com


### PR DESCRIPTION
This PR completes the #164 PR.
Fixes #135 