### PR TITLE
Added Github Action Workflow for Build.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,47 @@
+name: MicroProfile JWT Build
+
+on:
+  push:
+    paths-ignore:
+      - 'editorconfig'
+      - '.gitattributes'
+      - '.gitignore'
+      - 'CONTRIBUTING*'
+      - 'CODEOWNERS'
+      - 'KEYS'
+      - 'LICENSE'
+      - 'NOTICE'
+      - 'README*'
+      - 'site.yaml'
+  pull_request:
+    paths-ignore:
+      - 'editorconfig'
+      - '.gitattributes'
+      - '.gitignore'
+      - 'CONTRIBUTING*'
+      - 'CODEOWNERS'
+      - 'KEYS'
+      - 'LICENSE'
+      - 'NOTICE'
+      - 'README*'
+      - 'site.yaml'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [8, 11]
+    name: build with jdk ${{matrix.java}}
+
+    steps:
+      - uses: actions/checkout@v2
+        name: checkout
+
+      - uses: actions/setup-java@v1.3.0
+        name: set up jdk ${{matrix.java}}
+        with:
+          java-version: ${{matrix.java}}
+
+      - name: build with maven
+        run: mvn verify

--- a/pom.xml
+++ b/pom.xml
@@ -325,6 +325,7 @@
                         <exclude>.factorypath</exclude>
                         <exclude>.editorconfig</exclude>
                         <exclude>sandbox/**</exclude>
+                        <exclude>.github/**</exclude>
                     </excludes>
                 </configuration>
             </plugin>


### PR DESCRIPTION
We could move to Github Actions to handle Build and Release process for MicroProfile Config. Some of the main motivations to move are:

- Run the build in forks. You don't need to do the PR to check the status of the build
- Change the Build / Release configuration by just submitting a PR
- Committers have control over the CI
- Flexible to execute actions on Github Events

I've detailed some of the work done over SmallRye to use Github Actions here:
https://github.com/smallrye/smallrye-parent/wiki/SmallRye-Release-Process

The idea is not to pull the plug on Jenkins yet. We can run both in parallel. We can start with just the build part, which is easy to implement and go from there.