### PR TITLE
Add a TCK test for RSA keys of 1024 bit key length

### DIFF
--- a/spec/src/main/asciidoc/configuration.asciidoc
+++ b/spec/src/main/asciidoc/configuration.asciidoc
@@ -47,9 +47,11 @@ HTTPS request.
 
 ### Supported Signature Algorithms
 
-Support for RSA RS256 and Elliptical Curve Digital Signature Algorithm (ECDSA) ES256 is required.
+Support for RSA RS256 and Elliptic Curve Digital Signature Algorithm (ECDSA) ES256 is required.
 RSA keys used for creating and verifying RS256 signatures must be of 1024 or 2048 bits in length.
 Other RSA key sizes are allowed, but should be considered vendor-specific.
+
+[NOTE] Support for RSA keys of 1024 bits in length is deprecated and will become optional in the next major version of the MP JWT specification.
 
 Other asymmetric signature algorithms are allowed, but should be considered vendor-specific.
 This includes Digital Signature Algorithm (DSA), Diffie-Hellman (DS), Edwards-curve Digital Signature

--- a/tck/src/main/java/org/eclipse/microprofile/jwt/tck/util/TokenUtils.java
+++ b/tck/src/main/java/org/eclipse/microprofile/jwt/tck/util/TokenUtils.java
@@ -243,6 +243,7 @@ public class TokenUtils {
             }
             jws.setKey(pk);   
         }
+        jws.setDoKeyValidation(false);
         return jws.getCompactSerialization();
     }
 

--- a/tck/src/test/java/org/eclipse/microprofile/jwt/tck/container/jaxrs/RsaKeySignatureTest.java
+++ b/tck/src/test/java/org/eclipse/microprofile/jwt/tck/container/jaxrs/RsaKeySignatureTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2016-2020 Contributors to the Eclipse Foundation
+ *
+ *  See the NOTICE file(s) distributed with this work for additional
+ *  information regarding copyright ownership.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  You may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.eclipse.microprofile.jwt.tck.container.jaxrs;
+
+import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
+import static org.eclipse.microprofile.jwt.tck.TCKConstants.TEST_GROUP_JAXRS;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
+
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.Response;
+
+import org.eclipse.microprofile.jwt.tck.util.MpJwtTestVersion;
+import org.eclipse.microprofile.jwt.tck.util.TokenUtils;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.testng.Assert;
+import org.testng.Reporter;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+public class RsaKeySignatureTest extends Arquillian {
+
+    /**
+     * The test generated JWT token string
+     */
+    private static String token;
+
+    /**
+     * The base URL for the container under test
+     */
+    @ArquillianResource
+    private URL baseURL;
+
+    /**
+     * Create a CDI aware base web application archive
+     * @return the base base web application archive
+     * @throws IOException - on resource failure
+     */
+    @Deployment(testable=true)
+    public static WebArchive createDeployment() throws IOException {
+        URL config = RsaKeySignatureTest.class.getResource("/META-INF/microprofile-config-rsakey1024-location.properties");
+        URL publicKey = RsaKeySignatureTest.class.getResource("/rsaPublicKey1024bit.jwk");
+        WebArchive webArchive = ShrinkWrap
+            .create(WebArchive.class, "RsaKeySignatureTest.war")
+            .addAsManifestResource(new StringAsset(MpJwtTestVersion.MPJWT_V_1_2.name()), MpJwtTestVersion.MANIFEST_NAME)
+            .addAsResource(publicKey, "/rsaPublicKey1024bit.jwk")
+            .addClass(RolesEndpoint.class)
+            .addClass(TCKApplication.class)
+            .addAsWebInfResource("beans.xml", "beans.xml")
+            .addAsManifestResource(config, "microprofile-config.properties");
+        return webArchive;
+    }
+
+    @BeforeClass(alwaysRun=true)
+    public static void generateToken() throws Exception {
+        RSAPrivateKey privateKey = (RSAPrivateKey)TokenUtils.readJwkPrivateKey("/rsaPrivateKey1024bit.jwk");
+        Assert.assertEquals(privateKey.getModulus().bitLength(), 1024);
+        RSAPublicKey publicKey = (RSAPublicKey)TokenUtils.readJwkPublicKey("/rsaPublicKey1024bit.jwk");
+        Assert.assertEquals(publicKey.getModulus().bitLength(), 1024);
+        token = TokenUtils.signClaims(privateKey, "1024bit", "/Token1.json");
+    }
+
+    @RunAsClient
+    @Test(groups = TEST_GROUP_JAXRS,
+        description = "Validate a request with MP-JWT succeeds with HTTP_OK, and replies with hello, user={token upn claim}")
+    public void callEcho() throws Exception {
+        Reporter.log("callEcho, expect HTTP_OK");
+
+        String uri = baseURL.toExternalForm() + "endp/echo";
+        WebTarget echoEndpointTarget = ClientBuilder.newClient()
+            .target(uri)
+            .queryParam("input", "hello");
+        
+        Response response = echoEndpointTarget.request(TEXT_PLAIN).header(HttpHeaders.AUTHORIZATION, "Bearer "+token).get();
+        Assert.assertEquals(response.getStatus(), HttpURLConnection.HTTP_OK);
+        String reply = response.readEntity(String.class);
+        // Must return hello, user={token upn claim}
+        Assert.assertEquals(reply, "hello, user=jdoe@example.com");
+    }
+}

--- a/tck/src/test/resources/META-INF/microprofile-config-rsakey1024-location.properties
+++ b/tck/src/test/resources/META-INF/microprofile-config-rsakey1024-location.properties
@@ -1,0 +1,22 @@
+#
+#  Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  You may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+# A reference to the publicKey4k.pem contents embedded location
+mp.jwt.verify.publickey.location=/rsaPublicKey1024bit.jwk
+mp.jwt.verify.issuer=https://server.example.com

--- a/tck/src/test/resources/rsaPrivateKey1024bit.jwk
+++ b/tck/src/test/resources/rsaPrivateKey1024bit.jwk
@@ -1,0 +1,12 @@
+{
+  "kty":"RSA",
+  "kid": "1024bit",
+  "alg": "RS256",
+  "n":"gSP-Hczm79MiY4sIkGcNlT5oWWh29cxmu8yk9Jqx4GiSP_R4BhY4TqKeHMeiwn64VLQH24ux3kgtQgkvtAUt2X_toDy9LBpO3EvDfZXVabe34BqJY3ppaFtrfsYqwwhhZ0y5xpKmQy_Vtl_Hi2ps4L3hnxHbPvzCfFp4k0E1UZM",
+  "e":"AQAB","d":"ffZRg1e9Weei_105uUALa6s3tR3ECvSYsE1oCH5rSew12tPlzmoV-f18I65F_1gDC_uePnL_x0S3gFXdhcYXdVAooOBL_ZOhOcZo3nL7mAfCKWNcCzeHq9cSmBaW10FsXz30wba5IgmBmfl6rL3wfKjrnVnj4aaRPi4M5ayU2kE",
+  "p":"uIz6RFXo5dwquNarKvCbggYSE4Ltsf7Ek0bnoTKe-mbepeTprkSTMfS-Saz_b6uLMg9MmdZZrvSlMvBF5fU2Ow",
+  "q":"syNCYFjrAXLAiYLmlgp0Q_mIi_5P5kvm28XC2weftFJY8A3woS-4mXDi1TEoIWd5Gk9HBnSQ8Bz8yTM562EkiQ",
+  "dp":"cR1vs_zYIDM_OEXTaiFJn3trDux8FlIqWH7oMCRfzujIZPQWysqbUc5J58yST_bb_VXlRJFeLN8kdkFRBm6yyw",
+  "dq":"WGOwb7vQEUHe0LsfLa9w2M16W6EbKYYQHibBU7O6UI5FRgWK0u2qB0QVGJ6Nr5XPwnSVlhDUJzYWYOx-yq5_CQ",
+  "qi":"m_txnxtQmqX09OKUc-OqFE9_v3h_Dd8oE4lPIMc6U0Jw_8ZXwEFpgqBkZ0rLeTWq-g6Waw3snXnOb8ujbRMGFg"
+}

--- a/tck/src/test/resources/rsaPublicKey1024bit.jwk
+++ b/tck/src/test/resources/rsaPublicKey1024bit.jwk
@@ -1,0 +1,7 @@
+{
+  "kty":"RSA",
+  "kid": "1024bit",
+  "alg": "RS256",
+  "n":"gSP-Hczm79MiY4sIkGcNlT5oWWh29cxmu8yk9Jqx4GiSP_R4BhY4TqKeHMeiwn64VLQH24ux3kgtQgkvtAUt2X_toDy9LBpO3EvDfZXVabe34BqJY3ppaFtrfsYqwwhhZ0y5xpKmQy_Vtl_Hi2ps4L3hnxHbPvzCfFp4k0E1UZM",
+  "e":"AQAB"
+}

--- a/tck/src/test/resources/suites/tck-base-suite.xml
+++ b/tck/src/test/resources/suites/tck-base-suite.xml
@@ -83,6 +83,7 @@
             <class name="org.eclipse.microprofile.jwt.tck.config.jwe.PrivateKeyAsPEMClasspathTest" />
             <class name="org.eclipse.microprofile.jwt.tck.config.jwe.PrivateKeyAsJWKClasspathTest" />
             <class name="org.eclipse.microprofile.jwt.tck.config.jwe.PrivateKeyAsJWKSClasspathTest" />
+            <class name="org.eclipse.microprofile.jwt.tck.config.jwe.RsaKeySignatureTest" />
         </classes>
     </test>
 


### PR DESCRIPTION
Fixes #197

A simple test has been added to verify that a token signed with the 1024 bit length RSA key is accepted, it reuses the `RolesAllowed` endpoint

CC @darranl, @teddyjtorres