### PR TITLE
Fix mp.jwt.decrypt.key.location description

### DIFF
--- a/spec/src/main/asciidoc/configuration.asciidoc
+++ b/spec/src/main/asciidoc/configuration.asciidoc
@@ -403,7 +403,7 @@ See the <<claims-verification, Verification of JWT token claims>> section how to
 
 #### `mp.jwt.decrypt.key.location`
 
-The `mp.jwt.verify.decryptkey.location` config property allows for an external or internal location
+The `mp.jwt.decrypt.key.location` config property allows for an external or internal location
 of Private Decryption Key to be specified.  The value may be a relative path or a URL.
 Please see <<verification-publickey-location, mp.jwt.publickey.location>> for all the information about the supported locations and <<encrypted-jwt-tokens, Encrypted JWT claims and nested tokens>> section for the additional recommendations.
 


### PR DESCRIPTION
Fix minor typo in the mp.jwt.decrypt.key.location description.