### PR TITLE
LoginConfig: remove refs to all but the MP-JWT method and make MP-JWT the default one

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/auth/LoginConfig.java
+++ b/api/src/main/java/org/eclipse/microprofile/auth/LoginConfig.java
@@ -27,8 +27,10 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * A security annotation describing the authentication method, and the associated realm name that
+ * A security annotation describing the authentication method and the associated realm name that
  * should be used for this application.
+ *
+ * Note: this annotation may be removed in the future versions of the MP JWT specification.
  *
  */
 @Inherited
@@ -37,27 +39,19 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface LoginConfig {
     /**
-     * Soften the requirements here:
-     *
-     * The authMethod is used to configure the authentication mechanism for the
+     * The 'authMethod' is used to configure the "MP-JWT" authentication mechanism for the
      * JAX-RS application. As a prerequisite to gaining access to any web resources
      * which are protected by an authorization constraint, a user must have
-     * authenticated using the configured mechanism. Supported values include
-     * "BASIC", "DIGEST", "FORM", "CLIENT-CERT", "MP-JWT", or a vendor-specific
-     * authentication scheme.
-     *
-     * Note the the MP-JWT TCK currently only validates that a deployment with
-     * MP-JWT authentication follows the specification, but in the future,
-     * we MAY look to combine the use of MP-JWT tokens with other authentication
-     * mechanisms.
+     * authenticated using the configured mechanism.
+     * Support for the other authentication mechanisms is optional.
      *
      * @return the configured auth-method
      */
     String authMethod();
 
     /**
-     * The realm name element specifies the realm name to
-     use in HTTP Basic authorization.
+     * The realm name
+     *
      * @return the realm name which may be empty
      */
     String realmName() default "";


### PR DESCRIPTION
Related #182 

This PR is the first step in the long (possibly never ending) process of dropping `LoginConfig`:
- removes the references to all but `MP-JWT` methods - `MP-JWT` spec should really be only about JWT; note dropping these references from the doc only serves this purpose, i.e, stop sending the message that `LoginConfig` can be an annotation for all sort of auth mechanisms
- `MP-JWT` is a default method now - it does not break the backward compatibility since until now setting the auth method is required, I suspect in the vast majority of cases where this annotation is still used it is `@LoginConfig(authMethod="MP-JWT")` so at least the users will now be able to do just `@LoginConfig`...
- updated the baseline version in this package to `1.1` - I'm scared of this update the most :-), @Emily-Jiang, please check if it is correct

I really don't think we can do more about `@LoginConfig` in the short/medium term
Hi Romain, @rmannibucau, not sure why but could not add you as a reviewer, I'm doing this PR given your last comment at #182 
Also see @teddyjtorres 