### PR TITLE
Update WAR file names for TCK tests

### DIFF
--- a/tck/src/test/java/org/eclipse/microprofile/jwt/tck/config/ECPublicKeyAsPEMTest.java
+++ b/tck/src/test/java/org/eclipse/microprofile/jwt/tck/config/ECPublicKeyAsPEMTest.java
@@ -75,7 +75,7 @@ public class ECPublicKeyAsPEMTest extends Arquillian {
         URL config = ECPublicKeyAsPEMTest.class.getResource("/META-INF/microprofile-config-ecpublickey.properties");
 
         WebArchive webArchive = ShrinkWrap
-                .create(WebArchive.class, "PublicKeyAsPEMTest.war")
+                .create(WebArchive.class, "ECPublicKeyAsPEMTest.war")
             .addAsManifestResource(new StringAsset(MpJwtTestVersion.MPJWT_V_1_2.name()), MpJwtTestVersion.MANIFEST_NAME)
                 .addClass(PublicKeyEndpoint.class)
                 .addClass(TCKApplication.class)

--- a/tck/src/test/java/org/eclipse/microprofile/jwt/tck/container/jaxrs/ApplicationScopedInjectionTest.java
+++ b/tck/src/test/java/org/eclipse/microprofile/jwt/tck/container/jaxrs/ApplicationScopedInjectionTest.java
@@ -77,7 +77,7 @@ public class ApplicationScopedInjectionTest extends Arquillian {
         URL config = ApplicationScopedInjectionTest.class.getResource("/META-INF/microprofile-config-publickey-location.properties");
         URL publicKey = ApplicationScopedInjectionTest.class.getResource("/publicKey.pem");
         WebArchive webArchive = ShrinkWrap
-            .create(WebArchive.class, "ClaimValueInjectionTest.war")
+            .create(WebArchive.class, "ApplicationScopedInjectionTest.war")
             .addAsManifestResource(new StringAsset(MpJwtTestVersion.MPJWT_V_1_0.name()), MpJwtTestVersion.MANIFEST_NAME)
             .addAsResource(publicKey, "/publicKey.pem")
             .addClass(ApplicationScopedEndpoint.class)

--- a/tck/src/test/java/org/eclipse/microprofile/jwt/tck/container/jaxrs/AudArrayValidationTest.java
+++ b/tck/src/test/java/org/eclipse/microprofile/jwt/tck/container/jaxrs/AudArrayValidationTest.java
@@ -98,7 +98,7 @@ public class AudArrayValidationTest extends Arquillian {
         configProps.setProperty(Names.ISSUER, TCKConstants.TEST_ISSUER);
         configProps.setProperty(Names.AUDIENCES, "aud3,badAud,aud1");  // matches json, should pass
         StringWriter configSW = new StringWriter();
-        configProps.store(configSW, "AudValidationTest microprofile-config.properties");
+        configProps.store(configSW, "AudArrayValidationTest microprofile-config.properties");
         StringAsset configAsset = new StringAsset(configSW.toString());
 
         WebArchive webArchive = ShrinkWrap


### PR DESCRIPTION
Updates a few TCK test classes to ensure the WAR file generated for the test application is consistent with the test class name.

Signed-off-by: Adam Yoho <ayoho@us.ibm.com>