### PR TITLE
Add the build-helper-maven-plugin to attach spec artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@v2
         name: checkout
 
-      - uses: actions/setup-java@v1.3.0
+      - uses: actions/setup-java@v1.4.3
         name: set up jdk ${{matrix.java}}
         with:
           java-version: ${{matrix.java}}

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -35,6 +35,8 @@
         <license>Apache License v 2.0</license>
         <maven.build.timestamp.format>MMMM dd, yyyy</maven.build.timestamp.format>
         <revisiondate>${maven.build.timestamp}</revisiondate>
+        <config.spec.pdf>${project.build.directory}/generated-docs/${project.build.finalName}.pdf</config.spec.pdf>
+        <config.spec.html>${project.build.directory}/generated-docs/${project.build.finalName}.html</config.spec.html>
     </properties>
 
     <build>
@@ -90,6 +92,31 @@
                         <license>Apache License v2.0</license>
                     </attributes>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-artifacts</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>attach-artifact</goal>
+                        </goals>
+                        <configuration>
+                            <artifacts>
+                                <artifact>
+                                    <file>${config.spec.pdf}</file>
+                                    <type>pdf</type>
+                                </artifact>
+                                <artifact>
+                                    <file>${config.spec.html}</file>
+                                    <type>html</type>
+                                </artifact>
+                            </artifacts>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Signed-off-by: Scott M Stark <starksm64@gmail.com>

Addresses the issue I mentioned at https://groups.google.com/u/1/g/microprofile/c/T_XcmTbQp6Q where the
staged org.eclipse.microprofile.jwt:microprofile-jwt-auth-spec artifact is missing the html/pdf spec contents.