### PR TITLE
Correct the config.spec.* variables to not include the version.

### DIFF
--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -35,8 +35,8 @@
         <license>Apache License v 2.0</license>
         <maven.build.timestamp.format>MMMM dd, yyyy</maven.build.timestamp.format>
         <revisiondate>${maven.build.timestamp}</revisiondate>
-        <config.spec.pdf>${project.build.directory}/generated-docs/${project.build.finalName}.pdf</config.spec.pdf>
-        <config.spec.html>${project.build.directory}/generated-docs/${project.build.finalName}.html</config.spec.html>
+        <config.spec.pdf>${project.build.directory}/generated-docs/${project.artifactId}.pdf</config.spec.pdf>
+        <config.spec.html>${project.build.directory}/generated-docs/${project.artifactId}.html</config.spec.html>
     </properties>
 
     <build>


### PR DESCRIPTION
Running an install did not work. This fixes the problem with the config.spec.pdf/config.spec.html settings.

Signed-off-by: Scott M Stark <starksm64@gmail.com>