### PR TITLE
Minor JavaDoc and specification fixes

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/jwt/JsonWebToken.java
+++ b/api/src/main/java/org/eclipse/microprofile/jwt/JsonWebToken.java
@@ -70,8 +70,7 @@ public interface JsonWebToken extends Principal {
 
     /**
      * The sub(Subject) claim identifies the principal that is the subject of
-     * the JWT. This is the token issuing
-     * IDP subject, not the
+     * the JWT. This is the token issuing IDP subject.
      *
      * @return the sub claim.
      */

--- a/spec/src/main/asciidoc/interoperability.asciidoc
+++ b/spec/src/main/asciidoc/interoperability.asciidoc
@@ -146,8 +146,7 @@ public interface JsonWebToken extends Principal {
 
     /**
      * The sub(Subject) claim identifies the principal that is the subject of
-     * the JWT. This is the token issuing
-     * IDP subject, not the
+     * the JWT. This is the token issuing IDP subject.
      *
      * @return the sub claim.
      */
@@ -247,7 +246,7 @@ public interface JsonWebToken extends Principal {
 
 ### Additional Claims
 The JWT can contain any number of other custom and standard claims, and these are
-made available from the JsonWebToken getOtherClaim(String) method. An example
+made available from the JsonWebToken getClaim(String) method. An example
 MP-JWT that contains additional "auth_time", "preferred_username", "acr",
 "nbf", "aud" and "roles" claims is:
 


### PR DESCRIPTION
Fixes #234.
Fixes #235.

@keilw has reported these 2 issues and this PR fixes them. I don't think it requires a `1.2.1` maintenance release, these are the obvious and old typo/text bugs, no-one has noticed it during the last few years, so I'd not make a big deal out of it - it will be in the next platform release anyway. That said, I don't mind much doing a `1.2.1` tag. 
