### PR TITLE
Add Tests Ran in Base Suite to Full Suite

### DIFF
--- a/tck/src/test/resources/suites/tck-full-suite.xml
+++ b/tck/src/test/resources/suites/tck-full-suite.xml
@@ -28,6 +28,7 @@
                 <include name="cdi" description="Base CDI injection of ClaimValues"/>
                 <include name="cdi-json" description="CDI injection of JSON-P values"/>
                 <include name="cdi-provider" description="CDI injection of javax.inject.Provider values"/>
+                <include name="config" description="Validate configuration using MP-config"/>
             </define>
             <define name="excludes">
                 <include name="utils-extra" description="Additional utility tests" />
@@ -39,6 +40,9 @@
         </groups>
         <classes>
             <class name="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" />
+            <class name="org.eclipse.microprofile.jwt.tck.util.TokenUtilsEncryptTest" />
+            <class name="org.eclipse.microprofile.jwt.tck.util.TokenUtilsSignEncryptTest" />
+            <class name="org.eclipse.microprofile.jwt.tck.util.TokenUtilsExtraTest" />
             <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.UnsecuredPingTest" />
             <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.RequiredClaimsTest" />
             <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" />
@@ -46,6 +50,37 @@
             <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" />
             <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" />
             <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.InvalidTokenTest" />
+            <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.PrimitiveInjectionTest" />
+            <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.PrincipalInjectionTest" />
+            <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.AudValidationTest" />
+            <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.AudArrayValidationTest" />
+            <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.AudValidationBadAudTest" />
+            <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.AudValidationMissingAudTest" />
+            <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.ApplicationScopedInjectionTest" />
+            <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.RsaKeySignatureTest" />
+            <class name="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsPEMTest" />
+            <class name="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsPEMLocationTest" />
+            <class name="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsPEMLocationURLTest" />
+            <class name="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsJWKTest" />
+            <class name="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsJWKLocationTest" />
+            <class name="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsJWKLocationURLTest" />
+            <class name="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsJWKSTest" />
+            <class name="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsJWKSLocationTest" />
+            <class name="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsBase64JWKTest" />
+            <class name="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsFileLocationURLTest" />
+            <class name="org.eclipse.microprofile.jwt.tck.config.ECPublicKeyAsPEMTest" />
+            <class name="org.eclipse.microprofile.jwt.tck.config.ECPublicKeyAsPEMLocationTest" />
+            <class name="org.eclipse.microprofile.jwt.tck.config.ECPublicKeyAsJWKLocationTest" />
+            <class name="org.eclipse.microprofile.jwt.tck.config.IssValidationTest" />
+            <class name="org.eclipse.microprofile.jwt.tck.config.IssValidationFailTest" />
+            <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.CookieTokenTest" />
+            <class name="org.eclipse.microprofile.jwt.tck.config.TokenAsCookieIgnoredTest" />
+            <class name="org.eclipse.microprofile.jwt.tck.config.TokenAsCookieTest" />
+            <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.EmptyTokenTest" />
+            <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedSignEncryptTest" />
+            <class name="org.eclipse.microprofile.jwt.tck.config.jwe.PrivateKeyAsPEMClasspathTest" />
+            <class name="org.eclipse.microprofile.jwt.tck.config.jwe.PrivateKeyAsJWKClasspathTest" />
+            <class name="org.eclipse.microprofile.jwt.tck.config.jwe.PrivateKeyAsJWKSClasspathTest" />
         </classes>
     </test>
     <test name="extended-tests" verbose="10">


### PR DESCRIPTION
It appears the full-suite xml has fallen behind the base-suite and runs substantially fewer tests.