### PR TITLE
Fix ApplicationScopedInjectionTest#verifyInjectedRawTokenJwt Test

### DIFF
--- a/tck/src/test/java/org/eclipse/microprofile/jwt/tck/container/jaxrs/ApplicationScopedInjectionTest.java
+++ b/tck/src/test/java/org/eclipse/microprofile/jwt/tck/container/jaxrs/ApplicationScopedInjectionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016-2021 Contributors to the Eclipse Foundation
  *
  *  See the NOTICE file(s) distributed with this work for additional
  *  information regarding copyright ownership.
@@ -70,7 +70,7 @@ public class ApplicationScopedInjectionTest extends Arquillian {
 
     /**
      * Create a CDI aware base web application archive
-     * 
+     *
      * @return the base base web application archive
      * @throws IOException
      *             - on resource failure
@@ -112,7 +112,7 @@ public class ApplicationScopedInjectionTest extends Arquillian {
     @Test(groups = TEST_GROUP_CDI, description = "Verify that JsonWebToken.getRawToken returns the raw token as expected")
     public void verifyInjectedRawTokenJwt() throws Exception {
         Reporter.log("Begin verifyInjectedRawTokenJwt\n");
-        String uri = baseURL.toExternalForm() + "endp/verifyInjectedRawTokenProvider";
+        String uri = baseURL.toExternalForm() + "endp/verifyInjectedRawTokenJwt";
         verifyInjectedToken(uri, token1);
         verifyInjectedToken(uri, token2);
     }


### PR DESCRIPTION
This test is poking the wrong endpoint, essentially just rerunning one of the other tests.

Signed-off-by: Andrew Pielage <pandrex247@hotmail.com>