### PR TITLE
Add support for RSA-OAEP-256 key management algorithm

### DIFF
--- a/spec/src/main/asciidoc/configuration.asciidoc
+++ b/spec/src/main/asciidoc/configuration.asciidoc
@@ -381,7 +381,7 @@ Note that two types of keys are required to implement a JWE encryption scheme:
 * Content encryption key - typically a generated secret key which is used to encrypt a plaintext such as a JSON representation of the token claims.
 * Key management key - public RSA key which is used to encrypt a content encryption key. `mp.jwt.decrypt.key.location` must point to a private RSA key matching this key.
 
-Key management key algorithm which must be supported is https://tools.ietf.org/html/rfc7518#section-4.3[RSA-OAEP] (RSAES using Optimal Asymmetric Encryption Padding) with a key length 2048 bits or higher.
+Key management key algorithms which must be supported are https://tools.ietf.org/html/rfc7518#section-4.3[RSA-OAEP] (RSAES using Optimal Asymmetric Encryption Padding and SHA-1) and https://tools.ietf.org/html/rfc7518#section-4.3[RSA-OAEP-256] (RSAES using Optimal Asymmetric Encryption Padding and SHA-256) with a public RSA key length 2048 bits or higher.
 
 Content encryption algorithm which must be supported is https://tools.ietf.org/html/rfc7518#section-5.3[A256GCM] (AES in Galois/Counter Mode (GCM)).
 
@@ -408,6 +408,13 @@ See the <<claims-verification, Verification of JWT token claims>> section how to
 The `mp.jwt.decrypt.key.location` config property allows for an external or internal location
 of Private Decryption Key to be specified.  The value may be a relative path or a URL.
 Please see <<verification-publickey-location, mp.jwt.publickey.location>> for all the information about the supported locations and <<encrypted-jwt-tokens, Encrypted JWT claims and nested tokens>> section for the additional recommendations.
+
+#### `mp.jwt.decrypt.key.algorithm`
+
+The `mp.jwt.decrypt.key.algorithm` configuration property allows for specifying which key management key algorithm
+is supported by the MP JWT endpoint. Algorithms which must be supported are either `RSA-OAEP` or `RSA-OAEP-256`. Default value is `RSA-OAEP` but `RSA-OAEP-256` will become a default value in one of the next major releases.
+
+Support for the other key management key algorithm such as `RSA-OAEP-384`, `RSA-OAEP-512` and others is optional.
 
 [[claims-verification]]
 ## Verification of JWT token claims

--- a/tck/src/main/java/org/eclipse/microprofile/jwt/tck/util/KeyManagementAlgorithm.java
+++ b/tck/src/main/java/org/eclipse/microprofile/jwt/tck/util/KeyManagementAlgorithm.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016-2017 Contributors to the Eclipse Foundation
  *
  *  See the NOTICE file(s) distributed with this work for additional
  *  information regarding copyright ownership.
@@ -19,13 +19,17 @@
  */
 package org.eclipse.microprofile.jwt.tck.util;
 
-/**
- * An enum used to identify which version of the MP-JWT a TCK test war is targeting. The target version can be found by
- * loading the META-INF/MPJWTTESTVERSION resource from the test war and converting it to the MpJwtTestVersion value.
- */
-public enum MpJwtTestVersion {
-    MPJWT_V_1_0, MPJWT_V_1_1, MPJWT_V_1_2, MPJWT_V_2_1;
+public enum KeyManagementAlgorithm {
+    /**
+     * RSAES using Optimal Asymmetric Encryption Padding with SHA-1
+     */
+    RSA_OAEP,
+    /**
+     * RSAES using Optimal Asymmetric Encryption Padding with SHA-256
+     */
+    RSA_OAEP_256;
 
-    public static final String VERSION_LOCATION = "META-INF/MPJWTTESTVERSION";
-    public static final String MANIFEST_NAME = "MPJWTTESTVERSION";
+    public String getAlgorithm() {
+        return name().replace("_", "-");
+    }
 }

--- a/tck/src/test/java/org/eclipse/microprofile/jwt/tck/container/jaxrs/jwe/RolesAllowedSignEncryptRsaOaep256Test.java
+++ b/tck/src/test/java/org/eclipse/microprofile/jwt/tck/container/jaxrs/jwe/RolesAllowedSignEncryptRsaOaep256Test.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ *  See the NOTICE file(s) distributed with this work for additional
+ *  information regarding copyright ownership.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  You may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe;
+
+import static jakarta.ws.rs.core.MediaType.TEXT_PLAIN;
+import static org.eclipse.microprofile.jwt.tck.TCKConstants.TEST_GROUP_JAXRS;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+
+import org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesEndpoint;
+import org.eclipse.microprofile.jwt.tck.container.jaxrs.TCKApplication;
+import org.eclipse.microprofile.jwt.tck.util.KeyManagementAlgorithm;
+import org.eclipse.microprofile.jwt.tck.util.MpJwtTestVersion;
+import org.eclipse.microprofile.jwt.tck.util.TokenUtils;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.testng.Assert;
+import org.testng.Reporter;
+import org.testng.annotations.Test;
+
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.Response;
+
+/**
+ * Tests of the MP-JWT auth method authorization behavior as expected by the MP-JWT RBAC 1.0 spec
+ */
+public class RolesAllowedSignEncryptRsaOaep256Test extends Arquillian {
+
+    /**
+     * The base URL for the container under test
+     */
+    @ArquillianResource
+    private URL baseURL;
+
+    /**
+     * Create a CDI aware base web application archive
+     * 
+     * @return the base base web application archive
+     * @throws IOException
+     *             - on resource failure
+     */
+    @Deployment(testable = true)
+    public static WebArchive createDeployment() throws IOException {
+        URL config = RolesAllowedSignEncryptRsaOaep256Test.class
+                .getResource("/META-INF/microprofile-config-verify-decrypt-rsa-oaep-256.properties");
+        URL verifyKey = RolesAllowedSignEncryptRsaOaep256Test.class.getResource("/publicKey4k.pem");
+        URL decryptKey = RolesAllowedSignEncryptRsaOaep256Test.class.getResource("/privateKey.pem");
+        WebArchive webArchive = ShrinkWrap
+                .create(WebArchive.class, "RolesAllowedSignEncryptRsaOaep256Test.war")
+                .addAsManifestResource(new StringAsset(MpJwtTestVersion.MPJWT_V_2_1.name()),
+                        MpJwtTestVersion.MANIFEST_NAME)
+                .addAsResource(decryptKey, "/privateKey.pem")
+                .addAsResource(verifyKey, "/publicKey4k.pem")
+                .addClass(RolesEndpoint.class)
+                .addClass(TCKApplication.class)
+                .addAsWebInfResource("beans.xml", "beans.xml")
+                .addAsManifestResource(config, "microprofile-config.properties");
+        return webArchive;
+    }
+
+    @RunAsClient
+    @Test(groups = TEST_GROUP_JAXRS, description = "Validate a request with RSA-OAEP-256 encrypted token succeeds")
+    public void callEchoRsaOaep256() throws Exception {
+        Reporter.log("callEcho with RSA-OAEP-256 encrypted token, expect HTTP_OK");
+
+        PrivateKey signingKey = TokenUtils.readPrivateKey("/privateKey4k.pem");
+        PublicKey encryptionKey = TokenUtils.readPublicKey("/publicKey.pem");
+        String token =
+                TokenUtils.signEncryptClaims(signingKey, null, encryptionKey, KeyManagementAlgorithm.RSA_OAEP_256, null,
+                        "/Token1.json", true);
+
+        String uri = baseURL.toExternalForm() + "endp/echo";
+        WebTarget echoEndpointTarget = ClientBuilder.newClient()
+                .target(uri)
+                .queryParam("input", "hello");
+        Response response =
+                echoEndpointTarget.request(TEXT_PLAIN).header(HttpHeaders.AUTHORIZATION, "Bearer " + token).get();
+        Assert.assertEquals(response.getStatus(), HttpURLConnection.HTTP_OK);
+        String reply = response.readEntity(String.class);
+        // Must return hello, user={token upn claim}
+        Assert.assertEquals(reply, "hello, user=jdoe@example.com");
+    }
+
+    @RunAsClient
+    @Test(groups = TEST_GROUP_JAXRS, description = "Validate a request with RSA-OAEP encrypted token fails with HTTP_UNAUTHORIZED")
+    public void callEchoRsaOaep() throws Exception {
+        Reporter.log("callEcho with RSA-OAEP encrypted token, expect HTTP_UNAUTHORIZED");
+
+        String token = TokenUtils.signEncryptClaims("/Token1.json");
+        String uri = baseURL.toExternalForm() + "endp/echo";
+        WebTarget echoEndpointTarget = ClientBuilder.newClient()
+                .target(uri)
+                .queryParam("input", "hello");
+        Response response =
+                echoEndpointTarget.request(TEXT_PLAIN).header(HttpHeaders.AUTHORIZATION, "Bearer " + token).get();
+        Assert.assertEquals(response.getStatus(), HttpURLConnection.HTTP_UNAUTHORIZED);
+    }
+
+}

--- a/tck/src/test/resources/META-INF/microprofile-config-verify-decrypt-rsa-oaep-256.properties
+++ b/tck/src/test/resources/META-INF/microprofile-config-verify-decrypt-rsa-oaep-256.properties
@@ -1,0 +1,25 @@
+#
+#  Copyright (c) 2020 Contributors to the Eclipse Foundation
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  You may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+# A reference to the decryption privateKey.pem location
+mp.jwt.decrypt.key.location=/privateKey.pem
+mp.jwt.decrypt.key.algorithm=RSA-OAEP-256
+# A reference to the verification publicKey.pem location
+mp.jwt.verify.publickey.location=/publicKey4k.pem
+mp.jwt.verify.issuer=https://server.example.com

--- a/tck/src/test/resources/suites/tck-base-suite.xml
+++ b/tck/src/test/resources/suites/tck-base-suite.xml
@@ -78,6 +78,7 @@
             <class name="org.eclipse.microprofile.jwt.tck.config.TokenAsCookieTest" />
             <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.EmptyTokenTest" />
             <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedSignEncryptTest" />
+            <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedSignEncryptRsaOaep256Test" />
             <class name="org.eclipse.microprofile.jwt.tck.config.jwe.PrivateKeyAsPEMClasspathTest" />
             <class name="org.eclipse.microprofile.jwt.tck.config.jwe.PrivateKeyAsJWKClasspathTest" />
             <class name="org.eclipse.microprofile.jwt.tck.config.jwe.PrivateKeyAsJWKSClasspathTest" />


### PR DESCRIPTION
Fixes #289.

See #289 for all the details and specifically [this comment](https://github.com/eclipse/microprofile-jwt-auth/issues/289#issuecomment-1122205115).
In summary, an `mp.jwt.decrypt.key.algorithm` is introduced to prepare a transition to `RSA-OAEP-256` becoming a default algorithm used to decrypt the content encryption key. `RSA-OAEP` remains a default algorithm in 2.1. `RSA-OAEP-256` will become a new default in the next major release. `mp.jwt.decrypt.key.algorithm` might become a list property too.

CC @teddyjtorres @rdebusscher 