### PR TITLE
Allow impls to continue supporting stronger encryption by default

### DIFF
--- a/spec/src/main/asciidoc/configuration.asciidoc
+++ b/spec/src/main/asciidoc/configuration.asciidoc
@@ -412,7 +412,7 @@ Please see <<verification-publickey-location, mp.jwt.verify.publickey.location>>
 #### `mp.jwt.decrypt.key.algorithm`
 
 The `mp.jwt.decrypt.key.algorithm` configuration property allows for specifying which key management key algorithm
-is supported by the MP JWT endpoint. Algorithms which must be supported are either `RSA-OAEP` or `RSA-OAEP-256`. Default value is `RSA-OAEP` but `RSA-OAEP-256` will become a default value in one of the next major releases.
+is supported by the MP JWT endpoint. Algorithms which must be supported are either `RSA-OAEP` or `RSA-OAEP-256`. The recommended default value is `RSA-OAEP` but `RSA-OAEP-256` will become the recommended default value in one of the next major releases.
 
 Support for the other key management key algorithm such as `RSA-OAEP-384`, `RSA-OAEP-512` and others is optional.
 


### PR DESCRIPTION
I still think `mp.jwt.decrypt.key.algorithm` should support a list, but I'm happy to table that for MP JWT 3.0 so there's time to discuss -- we're out of runway for that kind of discussion/agreement.

The one tweak we would need before MP JWT 2.1 goes final is to remove the default for `mp.jwt.decrypt.key.algorithm`.  RSA-OAEP has been deprecated for a few years and our MP JWT 2.0 impl supports RSA-OAEP, RSA-OAEP-256, RSA-OAEP-384 and RSA-OAEP-512 out of the box.  It also supports ECDH-ES* algorithms.

The addition of `mp.jwt.decrypt.key.algorithm` is very good, but the default is unsafe and breaks existing applications.  They would need to make a code change to re-enable the safer algorithms that worked by default in our MP JWT 2.0 impl.

When we added the first config options in MP JWT 1.1 we stated that when the options were not used, you got the same behavior that you got before the option was added.  I've attempted to use the same language for `mp.jwt.decrypt.key.algorithm` so existing MP JWT 2.0 apps can still run with the safer algorithms without change.

This PR tweaks the TCK as well.

We'd be very happy to vote +1 on a MP JWT 2.1 with this change.  As well, provided we can get our own releasing done in time, we may even be able to help with a CCR for the MP JWT 2.1 final release.
