### PR TITLE
Add RolesAllowedSignEncryptRsaOaepTest and move negative RSA-OAEP-256 test to it from RolesAllowedSignEncryptTest

### DIFF
--- a/tck/src/test/java/org/eclipse/microprofile/jwt/tck/container/jaxrs/jwe/RolesAllowedSignEncryptTest.java
+++ b/tck/src/test/java/org/eclipse/microprofile/jwt/tck/container/jaxrs/jwe/RolesAllowedSignEncryptTest.java
@@ -34,7 +34,6 @@ import java.util.Base64;
 import org.eclipse.microprofile.jwt.tck.TCKConstants;
 import org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesEndpoint;
 import org.eclipse.microprofile.jwt.tck.container.jaxrs.TCKApplication;
-import org.eclipse.microprofile.jwt.tck.util.KeyManagementAlgorithm;
 import org.eclipse.microprofile.jwt.tck.util.MpJwtTestVersion;
 import org.eclipse.microprofile.jwt.tck.util.TokenUtils;
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -55,7 +54,8 @@ import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.Response;
 
 /**
- * Tests of the MP-JWT auth method authorization behavior as expected by the MP-JWT RBAC 1.0 spec
+ * Test that decryption of an inner signed JWT token encrypted using RSA-OAEP algorithm succeeds without having to
+ * configure `mp.jwt.decrypt.key.algorithm=RSA-OAEP`.
  */
 public class RolesAllowedSignEncryptTest extends Arquillian {
 
@@ -154,25 +154,6 @@ public class RolesAllowedSignEncryptTest extends Arquillian {
         String reply = response.readEntity(String.class);
         // Must return hello, user={token upn claim}
         Assert.assertEquals(reply, "hello, user=jdoe@example.com");
-    }
-
-    @RunAsClient
-    @Test(groups = TEST_GROUP_JAXRS, description = "Validate a request with RSA-OAEP-256 encrypted token fails with HTTP_UNAUTHORIZED")
-    public void callEchoRsaOaep256() throws Exception {
-        Reporter.log("callEcho with RSA-OAEP-356 encrypted token, expect HTTP_UNAUTHORIZED");
-
-        PrivateKey signingKey = TokenUtils.readPrivateKey("/privateKey4k.pem");
-        PublicKey encryptionKey = TokenUtils.readPublicKey("/publicKey.pem");
-        String token =
-                TokenUtils.signEncryptClaims(signingKey, null, encryptionKey, KeyManagementAlgorithm.RSA_OAEP_256, null,
-                        "/Token1.json", true);
-        String uri = baseURL.toExternalForm() + "endp/echo";
-        WebTarget echoEndpointTarget = ClientBuilder.newClient()
-                .target(uri)
-                .queryParam("input", "hello");
-        Response response =
-                echoEndpointTarget.request(TEXT_PLAIN).header(HttpHeaders.AUTHORIZATION, "Bearer " + token).get();
-        Assert.assertEquals(response.getStatus(), HttpURLConnection.HTTP_UNAUTHORIZED);
     }
 
     @RunAsClient

--- a/tck/src/test/resources/META-INF/microprofile-config-verify-decrypt-rsa-oaep.properties
+++ b/tck/src/test/resources/META-INF/microprofile-config-verify-decrypt-rsa-oaep.properties
@@ -1,0 +1,25 @@
+#
+#  Copyright (c) 2020 Contributors to the Eclipse Foundation
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  You may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+# A reference to the decryption privateKey.pem location
+mp.jwt.decrypt.key.location=/privateKey.pem
+mp.jwt.decrypt.key.algorithm=RSA-OAEP
+# A reference to the verification publicKey.pem location
+mp.jwt.verify.publickey.location=/publicKey4k.pem
+mp.jwt.verify.issuer=https://server.example.com

--- a/tck/src/test/resources/suites/tck-base-suite.xml
+++ b/tck/src/test/resources/suites/tck-base-suite.xml
@@ -78,6 +78,7 @@
             <class name="org.eclipse.microprofile.jwt.tck.config.TokenAsCookieTest" />
             <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.EmptyTokenTest" />
             <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedSignEncryptTest" />
+            <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedSignEncryptRsaOaepTest" />
             <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedSignEncryptRsaOaep256Test" />
             <class name="org.eclipse.microprofile.jwt.tck.config.jwe.PrivateKeyAsPEMClasspathTest" />
             <class name="org.eclipse.microprofile.jwt.tck.config.jwe.PrivateKeyAsJWKClasspathTest" />


### PR DESCRIPTION
CC @dblevins @teddyjtorres @rdebusscher 

As agreed in #298, the negative `RSA-OAEP-256` test has been updated to pass only if `mp.jwt.decrypt.key.algorithm=RSA-OAEP` is set.

Please review/approve asap, I'd like to release `RC4` tomorrow evening and then we can do the final one soon afterwards
