### PR TITLE
Recommend getting the sub claim to guarantee uniqueness in the JsonWebToken.getName JavaDocs

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/jwt/JsonWebToken.java
+++ b/api/src/main/java/org/eclipse/microprofile/jwt/JsonWebToken.java
@@ -31,8 +31,11 @@ import java.util.Set;
  */
 public interface JsonWebToken extends Principal {
     /**
-     * Returns the unique name of this principal. This either comes from the upn claim, or if that is missing, the
-     * preferred_username claim. Note that for guaranteed interoperability a upn claim should be used.
+     * Returns the unique name of this principal. The upn claim is checked first, the preferred_username claim is
+     * checked next, and finally, the sub claim is checked. Note that for guaranteed interoperability a upn claim should
+     * be used. However, the preferred_username claim is not guaranteed to be always unique. Therefore, if a truly
+     * unique principal identifier is required, prefer getting the sub claim directly by calling the
+     * {@link #getSubject()} method.
      *
      * @return the unique name of this principal.
      */
@@ -67,8 +70,8 @@ public interface JsonWebToken extends Principal {
     }
 
     /**
-     * The sub(Subject) claim identifies the principal that is the subject of the JWT. This is the token issuing IDP
-     * subject.
+     * The sub(Subject) claim uniquely identifies the principal that is the subject of the JWT. This is the token
+     * issuing IDP subject.
      *
      * @return the sub claim.
      */


### PR DESCRIPTION
My colleague spotted the problem, `preferred_username` is not unique, while JsonWebToken#getName talks about uniqueness.

This PR gently warns users that if they really need a unique principal identifier they should get a subject claim.
Ideally we'd remove any explicit mentioning of preferred_username - but it is hard to do right without possibly breaking a lot of user applications. May be in some basic cases it can be unique,  but definitely not in the OIDC space

CC @ayoho 